### PR TITLE
We can't retry these operations.

### DIFF
--- a/src/Transport/AMQPReceiver.php
+++ b/src/Transport/AMQPReceiver.php
@@ -55,10 +55,7 @@ class AMQPReceiver implements QueueReceiverInterface, MessageCountAwareInterface
     public function ack(Envelope $envelope): void
     {
         $amqpEnvelope = $this->findAMQPReceivedStamp($envelope)->getAMQPEnvelope();
-
-        $this->connection->withRetry(static function () use ($amqpEnvelope): void {
-            $amqpEnvelope->ack();
-        })->run();
+        $amqpEnvelope->ack();
     }
 
     /**
@@ -70,10 +67,7 @@ class AMQPReceiver implements QueueReceiverInterface, MessageCountAwareInterface
     public function reject(Envelope $envelope): void
     {
         $amqpEnvelope = $this->findAMQPReceivedStamp($envelope)->getAMQPEnvelope();
-
-        $this->connection->withRetry(static function () use ($amqpEnvelope): void {
-            $amqpEnvelope->nack();
-        })->run();
+        $amqpEnvelope->nack();
     }
 
     /** @throws TransportException */

--- a/src/Transport/Connection.php
+++ b/src/Transport/Connection.php
@@ -169,9 +169,11 @@ class Connection
                 );
             })->run();
 
-            $this->withRetry(function (): void {
+            try {
                 $this->channel()->wait_for_pending_acks(timeout: 3);
-            })->run();
+            } catch (AMQPExceptionInterface $e) {
+                throw new TransportException($e->getMessage(), 0, $e);
+            }
         }
     }
 


### PR DESCRIPTION
fixes #16

We can't retry ack/nack or wait_for_pending_acks because if the connection is closed, then the channel will also be closed so these would be retried on a new connection and channel, and it would fail.