### PR TITLE
Rename AMQP => Amqp and show available options in exception message

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Jwage\PhpAmqpLibMessengerBundle\RetryFactory;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPConnectionFactory;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPTransportFactory;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpConnectionFactory;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpTransportFactory;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\ConnectionFactory;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\DsnParser;
 use Psr\Log\LoggerInterface;
@@ -14,7 +14,7 @@ use Psr\Log\LoggerInterface;
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
 
-    $services->set(AMQPTransportFactory::class)
+    $services->set(AmqpTransportFactory::class)
         ->args([
             inline_service(ConnectionFactory::class)
                 ->args([
@@ -23,7 +23,7 @@ return static function (ContainerConfigurator $container): void {
                         ->args([
                             service(LoggerInterface::class),
                         ]),
-                    inline_service(AMQPConnectionFactory::class),
+                    inline_service(AmqpConnectionFactory::class),
                 ]),
             inline_service(RetryFactory::class)
                 ->args([

--- a/src/BatchMessageBus.php
+++ b/src/BatchMessageBus.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Jwage\PhpAmqpLibMessengerBundle;
 
 use InvalidArgumentException;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPBatchStamp;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpBatchStamp;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\BatchTransportInterface;
 use Override;
 use Symfony\Component\Messenger\Envelope;
@@ -71,7 +71,7 @@ class BatchMessageBus implements BatchMessageBusInterface
     public function dispatchInBatch(object $message, int $batchSize): Envelope
     {
         $envelope = Envelope::wrap($message)
-            ->with(new AMQPBatchStamp($batchSize));
+            ->with(new AmqpBatchStamp($batchSize));
 
         return $this->dispatch($envelope);
     }

--- a/src/Transport/AmqpBatchStamp.php
+++ b/src/Transport/AmqpBatchStamp.php
@@ -6,7 +6,7 @@ namespace Jwage\PhpAmqpLibMessengerBundle\Transport;
 
 use Symfony\Component\Messenger\Stamp\StampInterface;
 
-class AMQPBatchStamp implements StampInterface
+class AmqpBatchStamp implements StampInterface
 {
     public function __construct(
         private int $batchSize = 100,

--- a/src/Transport/AmqpConnectionFactory.php
+++ b/src/Transport/AmqpConnectionFactory.php
@@ -11,7 +11,7 @@ use PhpAmqpLib\Connection\AMQPStreamConnection;
 
 use function assert;
 
-class AMQPConnectionFactory
+class AmqpConnectionFactory
 {
     public function create(ConnectionConfig $connectionConfig): AMQPStreamConnection
     {

--- a/src/Transport/AmqpConsumer.php
+++ b/src/Transport/AmqpConsumer.php
@@ -12,7 +12,7 @@ use Symfony\Component\Messenger\Exception\TransportException;
 
 use function array_shift;
 
-class AMQPConsumer
+class AmqpConsumer
 {
     /** @var array<AMQPEnvelope> */
     private array $buffer = [];
@@ -81,6 +81,6 @@ class AMQPConsumer
 
     public function callback(AMQPMessage $amqpMessage): void
     {
-        $this->buffer[] = new AMQPEnvelope($amqpMessage);
+        $this->buffer[] = new AmqpEnvelope($amqpMessage);
     }
 }

--- a/src/Transport/AmqpEnvelope.php
+++ b/src/Transport/AmqpEnvelope.php
@@ -12,7 +12,7 @@ use function assert;
 use function is_numeric;
 use function is_string;
 
-class AMQPEnvelope
+class AmqpEnvelope
 {
     public function __construct(
         private AMQPMessage $amqpMessage,

--- a/src/Transport/AmqpReceivedStamp.php
+++ b/src/Transport/AmqpReceivedStamp.php
@@ -6,15 +6,15 @@ namespace Jwage\PhpAmqpLibMessengerBundle\Transport;
 
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 
-class AMQPReceivedStamp implements NonSendableStampInterface
+class AmqpReceivedStamp implements NonSendableStampInterface
 {
     public function __construct(
-        private AMQPEnvelope $amqpEnvelope,
+        private AmqpEnvelope $amqpEnvelope,
         private string $queueName,
     ) {
     }
 
-    public function getAMQPEnvelope(): AMQPEnvelope
+    public function getAMQPEnvelope(): AmqpEnvelope
     {
         return $this->amqpEnvelope;
     }

--- a/src/Transport/AmqpReceiver.php
+++ b/src/Transport/AmqpReceiver.php
@@ -16,7 +16,7 @@ use Symfony\Component\Messenger\Transport\Receiver\QueueReceiverInterface;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Throwable;
 
-class AMQPReceiver implements QueueReceiverInterface, MessageCountAwareInterface
+class AmqpReceiver implements QueueReceiverInterface, MessageCountAwareInterface
 {
     public function __construct(
         private Connection $connection,
@@ -117,14 +117,14 @@ class AMQPReceiver implements QueueReceiverInterface, MessageCountAwareInterface
                     ->with(new TransportMessageIdStamp($messageId));
             }
 
-            yield $envelope->with(new AMQPReceivedStamp($amqpEnvelope, $queueName));
+            yield $envelope->with(new AmqpReceivedStamp($amqpEnvelope, $queueName));
         }
     }
 
     /** @throws LogicException */
-    private function findAMQPReceivedStamp(Envelope $envelope): AMQPReceivedStamp
+    private function findAMQPReceivedStamp(Envelope $envelope): AmqpReceivedStamp
     {
-        $amqpReceivedStamp = $envelope->last(AMQPReceivedStamp::class);
+        $amqpReceivedStamp = $envelope->last(AmqpReceivedStamp::class);
 
         if ($amqpReceivedStamp === null) {
             throw new LogicException('No "AMQPReceivedStamp" stamp found on the Envelope.');

--- a/src/Transport/AmqpSender.php
+++ b/src/Transport/AmqpSender.php
@@ -17,7 +17,7 @@ use Throwable;
 use function assert;
 use function is_string;
 
-class AMQPSender implements SenderInterface, BatchSenderInterface
+class AmqpSender implements SenderInterface, BatchSenderInterface
 {
     public function __construct(
         private Connection $connection,
@@ -34,20 +34,20 @@ class AMQPSender implements SenderInterface, BatchSenderInterface
     {
         $encodedMessage = $this->serializer->encode($envelope);
 
-        $batchStamp = $envelope->last(AMQPBatchStamp::class);
+        $batchStamp = $envelope->last(AmqpBatchStamp::class);
         $batchSize  = $batchStamp ? $batchStamp->getBatchSize() : 1;
 
         $delayStamp = $envelope->last(DelayStamp::class);
         $delay      = $delayStamp ? $delayStamp->getDelay() : 0;
 
-        $amqpStamp = $envelope->last(AMQPStamp::class);
-        if ($amqpStamp instanceof AMQPStamp && isset($amqpStamp->getAttributes()['message_id'])) {
+        $amqpStamp = $envelope->last(AmqpStamp::class);
+        if ($amqpStamp instanceof AmqpStamp && isset($amqpStamp->getAttributes()['message_id'])) {
             $envelope = $envelope->with(new TransportMessageIdStamp($amqpStamp->getAttributes()['message_id']));
         }
 
-        $amqpReceivedStamp = $envelope->last(AMQPReceivedStamp::class);
-        if ($amqpReceivedStamp instanceof AMQPReceivedStamp) {
-            $amqpStamp = AMQPStamp::createFromAMQPEnvelope(
+        $amqpReceivedStamp = $envelope->last(AmqpReceivedStamp::class);
+        if ($amqpReceivedStamp instanceof AmqpReceivedStamp) {
+            $amqpStamp = AmqpStamp::createFromAMQPEnvelope(
                 $amqpReceivedStamp->getAMQPEnvelope(),
                 $amqpStamp,
                 $envelope->last(RedeliveryStamp::class) ? $amqpReceivedStamp->getQueueName() : null,

--- a/src/Transport/AmqpStamp.php
+++ b/src/Transport/AmqpStamp.php
@@ -6,7 +6,7 @@ namespace Jwage\PhpAmqpLibMessengerBundle\Transport;
 
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 
-class AMQPStamp implements NonSendableStampInterface
+class AmqpStamp implements NonSendableStampInterface
 {
     private bool $isRetryAttempt = false;
 
@@ -19,7 +19,7 @@ class AMQPStamp implements NonSendableStampInterface
 
     /** @psalm-suppress MixedAssignment */
     public static function createFromAMQPEnvelope(
-        AMQPEnvelope $amqpEnvelope,
+        AmqpEnvelope $amqpEnvelope,
         self|null $previousStamp = null,
         string|null $retryRoutingKey = null,
     ): self {

--- a/src/Transport/AmqpTransport.php
+++ b/src/Transport/AmqpTransport.php
@@ -15,12 +15,12 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\SetupableTransportInterface;
 use Throwable;
 
-class AMQPTransport implements QueueReceiverInterface, MessageCountAwareInterface, SetupableTransportInterface, BatchTransportInterface
+class AmqpTransport implements QueueReceiverInterface, MessageCountAwareInterface, SetupableTransportInterface, BatchTransportInterface
 {
     public function __construct(
         private Connection $connection,
-        private AMQPReceiver|null $receiver = null,
-        private AMQPSender|null $sender = null,
+        private AmqpReceiver|null $receiver = null,
+        private AmqpSender|null $sender = null,
         private SerializerInterface|null $serializer = null,
     ) {
     }
@@ -106,17 +106,17 @@ class AMQPTransport implements QueueReceiverInterface, MessageCountAwareInterfac
         return $this->serializer ??= new PhpSerializer();
     }
 
-    private function getReceiver(): AMQPReceiver
+    private function getReceiver(): AmqpReceiver
     {
-        return $this->receiver ??= new AMQPReceiver(
+        return $this->receiver ??= new AmqpReceiver(
             $this->connection,
             $this->getSerializer(),
         );
     }
 
-    private function getSender(): AMQPSender
+    private function getSender(): AmqpSender
     {
-        return $this->sender ??= new AMQPSender(
+        return $this->sender ??= new AmqpSender(
             $this->connection,
             $this->getSerializer(),
         );

--- a/src/Transport/AmqpTransportFactory.php
+++ b/src/Transport/AmqpTransportFactory.php
@@ -14,7 +14,7 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
 use function str_starts_with;
 
 /** @implements TransportFactoryInterface<AMQPTransport> */
-class AMQPTransportFactory implements TransportFactoryInterface
+class AmqpTransportFactory implements TransportFactoryInterface
 {
     public function __construct(
         private ConnectionFactory $connectionFactory,
@@ -37,7 +37,7 @@ class AMQPTransportFactory implements TransportFactoryInterface
 
         $connection = $this->connectionFactory->fromDsn($dsn, $options);
 
-        return new AMQPTransport(
+        return new AmqpTransport(
             connection: $connection,
             serializer: $serializer,
         );

--- a/src/Transport/Config/ConnectionConfig.php
+++ b/src/Transport/Config/ConnectionConfig.php
@@ -316,7 +316,7 @@ readonly class ConnectionConfig
     private static function validate(array $connectionConfig): void
     {
         if (0 < count($invalidOptions = array_diff(array_keys($connectionConfig), self::AVAILABLE_OPTIONS))) {
-            throw new InvalidArgumentException(sprintf('Invalid option(s) "%s" passed to the AMQP Messenger transport.', implode('", "', $invalidOptions)));
+            throw new InvalidArgumentException(sprintf('Invalid option(s) "%s" passed to the AMQP Messenger transport - known options: "%s".', implode('", "', $invalidOptions), implode('", "', self::AVAILABLE_OPTIONS)));
         }
     }
 

--- a/src/Transport/Connection.php
+++ b/src/Transport/Connection.php
@@ -26,7 +26,7 @@ class Connection
 
     private AMQPChannel|null $channel = null;
 
-    private AMQPConsumer|null $consumer = null;
+    private AmqpConsumer|null $consumer = null;
 
     private int $batchCount = 0;
 
@@ -36,7 +36,7 @@ class Connection
 
     public function __construct(
         private RetryFactory $retryFactory,
-        private AMQPConnectionFactory $amqpConnectionFactory,
+        private AmqpConnectionFactory $amqpConnectionFactory,
         private ConnectionConfig $connectionConfig,
     ) {
         $this->autoSetup      = $connectionConfig->autoSetup;
@@ -112,7 +112,7 @@ class Connection
             $this->setupExchangeAndQueues();
         }
 
-        yield from ($this->consumer ??= new AMQPConsumer($this, $this->connectionConfig))->get($queueName);
+        yield from ($this->consumer ??= new AmqpConsumer($this, $this->connectionConfig))->get($queueName);
     }
 
     /**
@@ -125,7 +125,7 @@ class Connection
         string $body,
         int $delayInMs = 0,
         int $batchSize = 1,
-        AMQPStamp|null $amqpStamp = null,
+        AmqpStamp|null $amqpStamp = null,
     ): void {
         if ($this->autoSetup) {
             $this->setupExchangeAndQueues();
@@ -239,7 +239,7 @@ class Connection
             });
     }
 
-    private function getRoutingKeyForMessage(AMQPStamp|null $amqpStamp): string|null
+    private function getRoutingKeyForMessage(AmqpStamp|null $amqpStamp): string|null
     {
         return $amqpStamp?->getRoutingKey() ?? $this->connectionConfig->exchange->defaultPublishRoutingKey;
     }
@@ -387,9 +387,9 @@ class Connection
         return $this->connection;
     }
 
-    private function createAMQPEnvelope(string $body): AMQPEnvelope
+    private function createAMQPEnvelope(string $body): AmqpEnvelope
     {
-        return new AMQPEnvelope(
+        return new AmqpEnvelope(
             new AMQPMessage(
                 $body,
                 [

--- a/src/Transport/ConnectionFactory.php
+++ b/src/Transport/ConnectionFactory.php
@@ -13,7 +13,7 @@ class ConnectionFactory
     public function __construct(
         private DsnParser $dsnParser,
         private RetryFactory $retryFactory,
-        private AMQPConnectionFactory $amqpConnectionFactory,
+        private AmqpConnectionFactory $amqpConnectionFactory,
     ) {
     }
 

--- a/tests/Transport/AmqpBatchStampTest.php
+++ b/tests/Transport/AmqpBatchStampTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Jwage\PhpAmqpLibMessengerBundle\Tests\Transport;
 
 use Jwage\PhpAmqpLibMessengerBundle\Tests\TestCase;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPBatchStamp;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpBatchStamp;
 
-class AMQPBatchStampTest extends TestCase
+class AmqpBatchStampTest extends TestCase
 {
-    private AMQPBatchStamp $stamp;
+    private AmqpBatchStamp $stamp;
 
     public function testConstruct(): void
     {
@@ -20,6 +20,6 @@ class AMQPBatchStampTest extends TestCase
     {
         parent::setUp();
 
-        $this->stamp = new AMQPBatchStamp(100);
+        $this->stamp = new AmqpBatchStamp(100);
     }
 }

--- a/tests/Transport/AmqpConnectionFactoryTest.php
+++ b/tests/Transport/AmqpConnectionFactoryTest.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Jwage\PhpAmqpLibMessengerBundle\Tests\Transport;
 
 use Jwage\PhpAmqpLibMessengerBundle\Tests\TestCase;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPConnectionFactory;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpConnectionFactory;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\Config\ConnectionConfig;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\Config\SslConfig;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 
-class AMQPConnectionFactoryTest extends TestCase
+class AmqpConnectionFactoryTest extends TestCase
 {
-    private AMQPConnectionFactory $amqpConnectionFactory;
+    private AmqpConnectionFactory $amqpConnectionFactory;
 
     public function testCreate(): void
     {
@@ -46,6 +46,6 @@ class AMQPConnectionFactoryTest extends TestCase
     {
         parent::setUp();
 
-        $this->amqpConnectionFactory = new AMQPConnectionFactory();
+        $this->amqpConnectionFactory = new AmqpConnectionFactory();
     }
 }

--- a/tests/Transport/AmqpConsumerTest.php
+++ b/tests/Transport/AmqpConsumerTest.php
@@ -6,8 +6,8 @@ namespace Jwage\PhpAmqpLibMessengerBundle\Tests\Transport;
 
 use Closure;
 use Jwage\PhpAmqpLibMessengerBundle\Tests\TestCase;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPConsumer;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPEnvelope;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpConsumer;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpEnvelope;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\Config\ConnectionConfig;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\Config\QueueConfig;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\Connection;
@@ -18,14 +18,14 @@ use Traversable;
 
 use function iterator_to_array;
 
-class AMQPConsumerTest extends TestCase
+class AmqpConsumerTest extends TestCase
 {
     /** @var MockObject&Connection */
     private Connection $connection;
 
     private ConnectionConfig $connectionConfig;
 
-    private AMQPConsumer $consumer;
+    private AmqpConsumer $consumer;
 
     public function testConsume(): void
     {
@@ -167,8 +167,8 @@ class AMQPConsumerTest extends TestCase
         $this->consumer = $this->getTestConsumer();
     }
 
-    private function getTestConsumer(ConnectionConfig|null $connectionConfig = null): AMQPConsumer
+    private function getTestConsumer(ConnectionConfig|null $connectionConfig = null): AmqpConsumer
     {
-        return new AMQPConsumer($this->connection, $connectionConfig ?? $this->connectionConfig);
+        return new AmqpConsumer($this->connection, $connectionConfig ?? $this->connectionConfig);
     }
 }

--- a/tests/Transport/AmqpEnvelopeTest.php
+++ b/tests/Transport/AmqpEnvelopeTest.php
@@ -5,18 +5,18 @@ declare(strict_types=1);
 namespace Jwage\PhpAmqpLibMessengerBundle\Tests\Transport;
 
 use Jwage\PhpAmqpLibMessengerBundle\Tests\TestCase;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPEnvelope;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpEnvelope;
 use OutOfBoundsException;
 use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Wire\AMQPTable;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class AMQPEnvelopeTest extends TestCase
+class AmqpEnvelopeTest extends TestCase
 {
     /** @var MockObject&AMQPMessage */
     private AMQPMessage $message;
 
-    private AMQPEnvelope $envelope;
+    private AmqpEnvelope $envelope;
 
     public function testGetAMQPMessage(): void
     {
@@ -229,7 +229,7 @@ class AMQPEnvelopeTest extends TestCase
             ],
         );
 
-        $envelope = new AMQPEnvelope($message);
+        $envelope = new AmqpEnvelope($message);
 
         self::assertSame('test body', $envelope->getBody());
         self::assertSame('text/plain', $envelope->getContentType());
@@ -243,6 +243,6 @@ class AMQPEnvelopeTest extends TestCase
 
         $this->message = $this->createMock(AMQPMessage::class);
 
-        $this->envelope = new AMQPEnvelope($this->message);
+        $this->envelope = new AmqpEnvelope($this->message);
     }
 }

--- a/tests/Transport/AmqpReceivedStampTest.php
+++ b/tests/Transport/AmqpReceivedStampTest.php
@@ -5,17 +5,17 @@ declare(strict_types=1);
 namespace Jwage\PhpAmqpLibMessengerBundle\Tests\Transport;
 
 use Jwage\PhpAmqpLibMessengerBundle\Tests\TestCase;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPEnvelope;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPReceivedStamp;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpEnvelope;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpReceivedStamp;
 use PhpAmqpLib\Message\AMQPMessage;
 
-class AMQPReceivedStampTest extends TestCase
+class AmqpReceivedStampTest extends TestCase
 {
     private AMQPMessage $message;
 
-    private AMQPEnvelope $envelope;
+    private AmqpEnvelope $envelope;
 
-    private AMQPReceivedStamp $stamp;
+    private AmqpReceivedStamp $stamp;
 
     public function testGetAMQPEnvelope(): void
     {
@@ -33,8 +33,8 @@ class AMQPReceivedStampTest extends TestCase
 
         $this->message = new AMQPMessage('test message');
 
-        $this->envelope = new AMQPEnvelope($this->message);
+        $this->envelope = new AmqpEnvelope($this->message);
 
-        $this->stamp = new AMQPReceivedStamp($this->envelope, 'queue_name');
+        $this->stamp = new AmqpReceivedStamp($this->envelope, 'queue_name');
     }
 }

--- a/tests/Transport/AmqpReceiverTest.php
+++ b/tests/Transport/AmqpReceiverTest.php
@@ -6,10 +6,10 @@ namespace Jwage\PhpAmqpLibMessengerBundle\Tests\Transport;
 
 use Jwage\PhpAmqpLibMessengerBundle\RetryFactory;
 use Jwage\PhpAmqpLibMessengerBundle\Tests\TestCase;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPConnectionFactory;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPEnvelope;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPReceivedStamp;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPReceiver;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpConnectionFactory;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpEnvelope;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpReceivedStamp;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpReceiver;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\Config\ConnectionConfig;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\Connection;
 use PhpAmqpLib\Message\AMQPMessage;
@@ -22,7 +22,7 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 use function serialize;
 
-class AMQPReceiverTest extends TestCase
+class AmqpReceiverTest extends TestCase
 {
     /** @var LoggerInterface&MockObject */
     private LoggerInterface $logger;
@@ -35,14 +35,14 @@ class AMQPReceiverTest extends TestCase
     /** @var SerializerInterface&MockObject */
     private SerializerInterface $serializer;
 
-    private AMQPReceiver $receiver;
+    private AmqpReceiver $receiver;
 
     public function testGet(): void
     {
         $message      = new stdClass();
         $envelope     = new Envelope($message);
         $amqpMessage  = new AMQPMessage(serialize($message), ['message_id' => '1']);
-        $amqpEnvelope = new AMQPEnvelope($amqpMessage);
+        $amqpEnvelope = new AmqpEnvelope($amqpMessage);
 
         $this->connection->expects(self::any())
             ->method('getQueueNames')
@@ -74,21 +74,21 @@ class AMQPReceiverTest extends TestCase
         self::assertInstanceOf(TransportMessageIdStamp::class, $transportMessageIdStamp1);
         self::assertSame('1', $transportMessageIdStamp1->getId());
 
-        $amqpReceivedStamp1 = $envelope1->last(AMQPReceivedStamp::class);
+        $amqpReceivedStamp1 = $envelope1->last(AmqpReceivedStamp::class);
 
-        self::assertInstanceOf(AMQPReceivedStamp::class, $amqpReceivedStamp1);
+        self::assertInstanceOf(AmqpReceivedStamp::class, $amqpReceivedStamp1);
         self::assertSame($amqpEnvelope, $amqpReceivedStamp1->getAMQPEnvelope());
         self::assertSame('queue_name', $amqpReceivedStamp1->getQueueName());
     }
 
     public function testAck(): void
     {
-        $amqpEnvelope = $this->createMock(AMQPEnvelope::class);
+        $amqpEnvelope = $this->createMock(AmqpEnvelope::class);
 
         $amqpEnvelope->expects(self::once())
             ->method('ack');
 
-        $stamp = new AMQPReceivedStamp($amqpEnvelope, 'queue_name');
+        $stamp = new AmqpReceivedStamp($amqpEnvelope, 'queue_name');
 
         $envelope = new Envelope(new stdClass(), [$stamp]);
 
@@ -97,12 +97,12 @@ class AMQPReceiverTest extends TestCase
 
     public function testReject(): void
     {
-        $amqpEnvelope = $this->createMock(AMQPEnvelope::class);
+        $amqpEnvelope = $this->createMock(AmqpEnvelope::class);
 
         $amqpEnvelope->expects(self::once())
             ->method('nack');
 
-        $stamp = new AMQPReceivedStamp($amqpEnvelope, 'queue_name');
+        $stamp = new AmqpReceivedStamp($amqpEnvelope, 'queue_name');
 
         $envelope = new Envelope(new stdClass(), [$stamp]);
 
@@ -126,7 +126,7 @@ class AMQPReceiverTest extends TestCase
 
         $this->retryFactory = new RetryFactory($this->logger);
 
-        $amqpConnectionFactory = new AMQPConnectionFactory();
+        $amqpConnectionFactory = new AmqpConnectionFactory();
         $connectionConfig      = new ConnectionConfig();
 
         $this->connection = $this->getMockBuilder(Connection::class)
@@ -136,7 +136,7 @@ class AMQPReceiverTest extends TestCase
 
         $this->serializer = $this->createMock(SerializerInterface::class);
 
-        $this->receiver = new AMQPReceiver(
+        $this->receiver = new AmqpReceiver(
             $this->connection,
             $this->serializer,
         );

--- a/tests/Transport/AmqpSenderTest.php
+++ b/tests/Transport/AmqpSenderTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Jwage\PhpAmqpLibMessengerBundle\Tests\Transport;
 
 use Jwage\PhpAmqpLibMessengerBundle\Tests\TestCase;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPBatchStamp;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPEnvelope;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPReceivedStamp;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPSender;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPStamp;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpBatchStamp;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpEnvelope;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpReceivedStamp;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpSender;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpStamp;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\Connection;
 use PhpAmqpLib\Message\AMQPMessage;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -18,7 +18,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
-class AMQPSenderTest extends TestCase
+class AmqpSenderTest extends TestCase
 {
     /** @var Connection&MockObject */
     private Connection $connection;
@@ -26,17 +26,17 @@ class AMQPSenderTest extends TestCase
     /** @var SerializerInterface&MockObject */
     private SerializerInterface $serializer;
 
-    private AMQPSender $sender;
+    private AmqpSender $sender;
 
     public function testSend(): void
     {
-        $amqpEnvelope = new AMQPEnvelope(new AMQPMessage('test'));
+        $amqpEnvelope = new AmqpEnvelope(new AMQPMessage('test'));
 
-        $amqpBatchStamp = new AMQPBatchStamp(1);
+        $amqpBatchStamp = new AmqpBatchStamp(1);
 
         $delayStamp = new DelayStamp(1000);
 
-        $amqpStamp = new AMQPStamp(null, [
+        $amqpStamp = new AmqpStamp(null, [
             'message_id' => '123',
             'headers' => [],
             'content_type' => null,
@@ -53,7 +53,7 @@ class AMQPSenderTest extends TestCase
             'type' => null,
         ]);
 
-        $amqpReceivedStamp = new AMQPReceivedStamp($amqpEnvelope, 'queue_name');
+        $amqpReceivedStamp = new AmqpReceivedStamp($amqpEnvelope, 'queue_name');
 
         $message  = new stdClass();
         $envelope = new Envelope($message, [
@@ -90,7 +90,7 @@ class AMQPSenderTest extends TestCase
 
         $this->serializer = $this->createMock(SerializerInterface::class);
 
-        $this->sender = new AMQPSender(
+        $this->sender = new AmqpSender(
             $this->connection,
             $this->serializer,
         );

--- a/tests/Transport/AmqpStampTest.php
+++ b/tests/Transport/AmqpStampTest.php
@@ -5,19 +5,19 @@ declare(strict_types=1);
 namespace Jwage\PhpAmqpLibMessengerBundle\Tests\Transport;
 
 use Jwage\PhpAmqpLibMessengerBundle\Tests\TestCase;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPEnvelope;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPStamp;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpEnvelope;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpStamp;
 use PhpAmqpLib\Message\AMQPMessage;
 
-class AMQPStampTest extends TestCase
+class AmqpStampTest extends TestCase
 {
-    private AMQPStamp $stamp;
+    private AmqpStamp $stamp;
 
     public function testCreateFromAMQPEnvelope(): void
     {
-        $amqpEnvelope = new AMQPEnvelope(new AMQPMessage('test'));
+        $amqpEnvelope = new AmqpEnvelope(new AMQPMessage('test'));
 
-        $stamp = AMQPStamp::createFromAMQPEnvelope(amqpEnvelope: $amqpEnvelope, retryRoutingKey: 'test');
+        $stamp = AmqpStamp::createFromAMQPEnvelope(amqpEnvelope: $amqpEnvelope, retryRoutingKey: 'test');
 
         self::assertSame('test', $stamp->getRoutingKey());
 
@@ -42,9 +42,9 @@ class AMQPStampTest extends TestCase
 
     public function testCreateFromAMQPEnvelopeWithoutRetryRoutingKey(): void
     {
-        $amqpEnvelope = new AMQPEnvelope(new AMQPMessage('test'));
+        $amqpEnvelope = new AmqpEnvelope(new AMQPMessage('test'));
 
-        $stamp = AMQPStamp::createFromAMQPEnvelope(amqpEnvelope: $amqpEnvelope);
+        $stamp = AmqpStamp::createFromAMQPEnvelope(amqpEnvelope: $amqpEnvelope);
 
         self::assertNull($stamp->getRoutingKey());
         self::assertFalse($stamp->isRetryAttempt());
@@ -69,6 +69,6 @@ class AMQPStampTest extends TestCase
     {
         parent::setUp();
 
-        $this->stamp = new AMQPStamp('test', ['test' => true]);
+        $this->stamp = new AmqpStamp('test', ['test' => true]);
     }
 }

--- a/tests/Transport/AmqpTransportFactoryTest.php
+++ b/tests/Transport/AmqpTransportFactoryTest.php
@@ -5,18 +5,18 @@ declare(strict_types=1);
 namespace Jwage\PhpAmqpLibMessengerBundle\Tests\Transport;
 
 use Jwage\PhpAmqpLibMessengerBundle\Tests\TestCase;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPTransport;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPTransportFactory;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpTransport;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpTransportFactory;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\ConnectionFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
-class AMQPTransportFactoryTest extends TestCase
+class AmqpTransportFactoryTest extends TestCase
 {
     /** @var ConnectionFactory&MockObject */
     private ConnectionFactory $connectionFactory;
 
-    private AMQPTransportFactory $factory;
+    private AmqpTransportFactory $factory;
 
     public function testCreateTransport(): void
     {
@@ -24,7 +24,7 @@ class AMQPTransportFactoryTest extends TestCase
 
         $transport = $this->factory->createTransport('phpamqplib://localhost', [], $serializer);
 
-        self::assertInstanceOf(AMQPTransport::class, $transport);
+        self::assertInstanceOf(AmqpTransport::class, $transport);
     }
 
     public function testSupports(): void
@@ -40,6 +40,6 @@ class AMQPTransportFactoryTest extends TestCase
 
         $this->connectionFactory = $this->createMock(ConnectionFactory::class);
 
-        $this->factory = new AMQPTransportFactory($this->connectionFactory);
+        $this->factory = new AmqpTransportFactory($this->connectionFactory);
     }
 }

--- a/tests/Transport/AmqpTransportTest.php
+++ b/tests/Transport/AmqpTransportTest.php
@@ -5,30 +5,30 @@ declare(strict_types=1);
 namespace Jwage\PhpAmqpLibMessengerBundle\Tests\Transport;
 
 use Jwage\PhpAmqpLibMessengerBundle\Tests\TestCase;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPReceiver;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPSender;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPTransport;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpReceiver;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpSender;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpTransport;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\Connection;
 use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
-class AMQPTransportTest extends TestCase
+class AmqpTransportTest extends TestCase
 {
     /** @var Connection&MockObject */
     private Connection $connection;
 
     /** @var AMQPReceiver&MockObject */
-    private AMQPReceiver $receiver;
+    private AmqpReceiver $receiver;
 
     /** @var AMQPSender&MockObject */
-    private AMQPSender $sender;
+    private AmqpSender $sender;
 
     /** @var SerializerInterface&MockObject */
     private SerializerInterface $serializer;
 
-    private AMQPTransport $transport;
+    private AmqpTransport $transport;
 
     public function testGetConnection(): void
     {
@@ -106,13 +106,13 @@ class AMQPTransportTest extends TestCase
 
         $this->connection = $this->createMock(Connection::class);
 
-        $this->receiver = $this->createMock(AMQPReceiver::class);
+        $this->receiver = $this->createMock(AmqpReceiver::class);
 
-        $this->sender = $this->createMock(AMQPSender::class);
+        $this->sender = $this->createMock(AmqpSender::class);
 
         $this->serializer = $this->createMock(SerializerInterface::class);
 
-        $this->transport = new AMQPTransport(
+        $this->transport = new AmqpTransport(
             connection: $this->connection,
             receiver: $this->receiver,
             sender: $this->sender,

--- a/tests/Transport/Config/ConnectionConfigTest.php
+++ b/tests/Transport/Config/ConnectionConfigTest.php
@@ -52,7 +52,7 @@ class ConnectionConfigTest extends TestCase
     public function testFromArrayWithInvalidOptions(): void
     {
         self::expectException(InvalidArgumentException::class);
-        self::expectExceptionMessage('Invalid option(s) "invalid" passed to the AMQP Messenger transport.');
+        self::expectExceptionMessage('Invalid option(s) "invalid" passed to the AMQP Messenger transport - known options:');
 
         ConnectionConfig::fromArray(['invalid' => true]);
     }

--- a/tests/Transport/ConnectionFactoryTest.php
+++ b/tests/Transport/ConnectionFactoryTest.php
@@ -6,7 +6,7 @@ namespace Jwage\PhpAmqpLibMessengerBundle\Tests\Transport;
 
 use Jwage\PhpAmqpLibMessengerBundle\RetryFactory;
 use Jwage\PhpAmqpLibMessengerBundle\Tests\TestCase;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPConnectionFactory;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpConnectionFactory;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\Config\SslConfig;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\ConnectionFactory;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\DsnParser;
@@ -17,7 +17,7 @@ class ConnectionFactoryTest extends TestCase
 
     private RetryFactory $retryFactory;
 
-    private AMQPConnectionFactory $amqpConnectionFactory;
+    private AmqpConnectionFactory $amqpConnectionFactory;
 
     private ConnectionFactory $connectionFactory;
 
@@ -47,7 +47,7 @@ class ConnectionFactoryTest extends TestCase
 
         $this->dsnParser             = new DsnParser();
         $this->retryFactory          = new RetryFactory();
-        $this->amqpConnectionFactory = new AMQPConnectionFactory();
+        $this->amqpConnectionFactory = new AmqpConnectionFactory();
 
         $this->connectionFactory = new ConnectionFactory(
             $this->dsnParser,

--- a/tests/Transport/ConnectionTest.php
+++ b/tests/Transport/ConnectionTest.php
@@ -6,8 +6,8 @@ namespace Jwage\PhpAmqpLibMessengerBundle\Tests\Transport;
 
 use Jwage\PhpAmqpLibMessengerBundle\RetryFactory;
 use Jwage\PhpAmqpLibMessengerBundle\Tests\TestCase;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPConnectionFactory;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPEnvelope;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpConnectionFactory;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpEnvelope;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\Config\BindingConfig;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\Config\ConnectionConfig;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\Config\ExchangeConfig;
@@ -29,7 +29,7 @@ class ConnectionTest extends TestCase
     private RetryFactory $retryFactory;
 
     /** @var AMQPConnectionFactory&MockObject */
-    private AMQPConnectionFactory $amqpConnectionFactory;
+    private AmqpConnectionFactory $amqpConnectionFactory;
 
     /** @var AMQPStreamConnection&MockObject */
     private AMQPStreamConnection $amqpConnection;
@@ -311,7 +311,7 @@ class ConnectionTest extends TestCase
 
         $this->retryFactory = new RetryFactory();
 
-        $this->amqpConnectionFactory = $this->createMock(AMQPConnectionFactory::class);
+        $this->amqpConnectionFactory = $this->createMock(AmqpConnectionFactory::class);
 
         $this->amqpConnection = $this->createMock(AMQPStreamConnection::class);
 

--- a/tests/TransportFunctionalTest.php
+++ b/tests/TransportFunctionalTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Jwage\PhpAmqpLibMessengerBundle\Tests;
 
 use Jwage\PhpAmqpLibMessengerBundle\BatchMessageBusInterface;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AMQPTransport;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpTransport;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Messenger\Envelope;
 use Traversable;
@@ -17,7 +17,7 @@ class TransportFunctionalTest extends KernelTestCase
 {
     private BatchMessageBusInterface $bus;
 
-    private AMQPTransport $transport;
+    private AmqpTransport $transport;
 
     public function testTransport(): void
     {
@@ -58,7 +58,7 @@ class TransportFunctionalTest extends KernelTestCase
         $this->bus = $container->get(BatchMessageBusInterface::class);
 
         $transport = $container->get('messenger.transport.test_phpamqplib');
-        assert($transport instanceof AMQPTransport);
+        assert($transport instanceof AmqpTransport);
 
         $this->transport = $transport;
     }


### PR DESCRIPTION
- Renames AMQP => Amqp to be consistent with Symfony
- Show the available options in the exception message when a key is not recognised

```
[InvalidArgumentException]
  Invalid option(s) "pefetch_count" passed to the AMQP Messenger transport - known options: "auto_setup", "host", "port", "user", "password", "vhost", "insis
  t", "login_method", "locale", "connection_timeout", "read_timeout", "write_timeout", "channel_rpc_timeout", "heartbeat", "keepalive", "prefetch_count", "wa
  it_timeout", "confirm_enabled", "confirm_timeout", "ssl", "exchange", "delay", "queues".
```