### PR TITLE
Fix spelling of Defer(rable/red)

### DIFF
--- a/src/Batch.php
+++ b/src/Batch.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Jwage\PhpAmqpLibMessengerBundle;
 
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferable;
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Defered;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferrable;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferred;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\BatchTransportInterface;
 use Override;
 use Symfony\Component\Messenger\Envelope;
@@ -32,11 +32,11 @@ class Batch implements MessageBusInterface
     public function dispatch(object $message, array $stamps = []): Envelope
     {
         $envelope = Envelope::wrap($message)
-            ->with(new Deferable($this->batchSize));
+            ->with(new Deferrable($this->batchSize));
 
         $envelope = $this->wrappedBus->dispatch($envelope);
 
-        if (($stamp = $envelope->last(Defered::class)) !== null) {
+        if (($stamp = $envelope->last(Deferred::class)) !== null) {
             $this->transportsToFlush[] = $stamp->getTransport();
         }
 

--- a/src/Stamp/Deferrable.php
+++ b/src/Stamp/Deferrable.php
@@ -6,7 +6,7 @@ namespace Jwage\PhpAmqpLibMessengerBundle\Stamp;
 
 use Symfony\Component\Messenger\Stamp\StampInterface;
 
-class Deferable implements StampInterface
+class Deferrable implements StampInterface
 {
     public function __construct(
         private int $batchSize,

--- a/src/Stamp/Deferred.php
+++ b/src/Stamp/Deferred.php
@@ -7,7 +7,7 @@ namespace Jwage\PhpAmqpLibMessengerBundle\Stamp;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\BatchTransportInterface;
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 
-class Defered implements NonSendableStampInterface
+class Deferred implements NonSendableStampInterface
 {
     public function __construct(
         private BatchTransportInterface $transport,

--- a/src/Transport/AmqpSender.php
+++ b/src/Transport/AmqpSender.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jwage\PhpAmqpLibMessengerBundle\Transport;
 
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferable;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferrable;
 use Override;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\TransportException;
@@ -35,8 +35,8 @@ class AmqpSender implements SenderInterface, BatchSenderInterface
     {
         $encodedMessage = $this->serializer->encode($envelope);
 
-        $deferable = $envelope->last(Deferable::class);
-        $batchSize = $deferable ? $deferable->getBatchSize() : 1;
+        $deferrable = $envelope->last(Deferrable::class);
+        $batchSize  = $deferrable ? $deferrable->getBatchSize() : 1;
 
         $delayStamp = $envelope->last(DelayStamp::class);
         $delay      = $delayStamp ? $delayStamp->getDelay() : 0;

--- a/src/Transport/AmqpTransport.php
+++ b/src/Transport/AmqpTransport.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Jwage\PhpAmqpLibMessengerBundle\Transport;
 
 use InvalidArgumentException;
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferable;
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Defered;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferrable;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferred;
 use Override;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\TransportException;
@@ -77,8 +77,8 @@ class AmqpTransport implements QueueReceiverInterface, MessageCountAwareInterfac
     #[Override]
     public function send(Envelope $envelope): Envelope
     {
-        if ($envelope->last(Deferable::class) !== null) {
-            $envelope = $envelope->with(new Defered($this));
+        if ($envelope->last(Deferrable::class) !== null) {
+            $envelope = $envelope->with(new Deferred($this));
         }
 
         return $this->getSender()->send($envelope);

--- a/tests/BatchTest.php
+++ b/tests/BatchTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Jwage\PhpAmqpLibMessengerBundle\Tests;
 
 use Jwage\PhpAmqpLibMessengerBundle\Batch;
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferable;
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Defered;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferrable;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferred;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\BatchTransportInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
@@ -32,12 +32,12 @@ class BatchTest extends TestCase
         $message2 = new stdClass();
 
         $envelope1 = Envelope::wrap($message1)
-            ->with(new Deferable(10))
-            ->with(new Defered($this->transport1));
+            ->with(new Deferrable(10))
+            ->with(new Deferred($this->transport1));
 
         $envelope2 = Envelope::wrap($message2)
-            ->with(new Deferable(10))
-            ->with(new Defered($this->transport2));
+            ->with(new Deferrable(10))
+            ->with(new Deferred($this->transport2));
 
         $this->wrappedBus->expects(self::exactly(2))
             ->method('dispatch')

--- a/tests/Transport/AmqpSenderTest.php
+++ b/tests/Transport/AmqpSenderTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jwage\PhpAmqpLibMessengerBundle\Tests\Transport;
 
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferable;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferrable;
 use Jwage\PhpAmqpLibMessengerBundle\Tests\TestCase;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpEnvelope;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpReceivedStamp;
@@ -32,7 +32,7 @@ class AmqpSenderTest extends TestCase
     {
         $amqpEnvelope = new AmqpEnvelope(new AMQPMessage('test'));
 
-        $deferableStamp = new Deferable(1);
+        $deferrableStamp = new Deferrable(1);
 
         $delayStamp = new DelayStamp(1000);
 
@@ -57,7 +57,7 @@ class AmqpSenderTest extends TestCase
 
         $message  = new stdClass();
         $envelope = new Envelope($message, [
-            $deferableStamp,
+            $deferrableStamp,
             $delayStamp,
             $amqpStamp,
             $amqpReceivedStamp,


### PR DESCRIPTION
While "deferable" is an alternative spelling of "deferrable", "defered" isn't in the [dictionary](https://en.wiktionary.org/w/index.php?go=Go&search=defered&title=Special%3ASearch&ns0=1).