### PR TITLE
Suppress log output in tests and workaround PHP error handler issue

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          cacheDirectory=".phpunit.cache"
          executionOrder="depends,defects"
          requireCoverageMetadata="false"
@@ -28,5 +28,6 @@
         <env name="APP_ENV" value="test"/>
         <env name="KERNEL_CLASS" value="Jwage\PhpAmqpLibMessengerBundle\Tests\TestKernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <server name="SHELL_VERBOSITY" value="-1" />
     </php>
 </phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\ErrorHandler\ErrorHandler;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+set_exception_handler([new ErrorHandler(), 'handleException']);


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/2191a4d8-9e0d-46f1-b53b-d133b2b5c2a7)

After:

![image](https://github.com/user-attachments/assets/8b6021f4-c2cb-4776-a807-2ba4bcf66255)
