### PR TITLE
POC Flush Transports via. Message

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -15,7 +15,8 @@ use Psr\Log\LoggerInterface;
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
 
-    $services->set(AmqpFlushMiddlware::class);
+    $services->set(AmqpFlushMiddlware::class)
+        ->arg(0, service('messenger.senders_locator'));
     $services->set(AmqpTransportFactory::class)
         ->args([
             inline_service(ConnectionFactory::class)

--- a/config/services.php
+++ b/config/services.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Jwage\PhpAmqpLibMessengerBundle\Middleware\AmqpFlushMiddlware;
 use Jwage\PhpAmqpLibMessengerBundle\RetryFactory;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpConnectionFactory;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpTransportFactory;
@@ -14,6 +15,7 @@ use Psr\Log\LoggerInterface;
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
 
+    $services->set(AmqpFlushMiddlware::class);
     $services->set(AmqpTransportFactory::class)
         ->args([
             inline_service(ConnectionFactory::class)

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          cacheDirectory=".phpunit.cache"
          executionOrder="depends,defects"
          requireCoverageMetadata="false"
@@ -28,5 +28,6 @@
         <env name="APP_ENV" value="test"/>
         <env name="KERNEL_CLASS" value="Jwage\PhpAmqpLibMessengerBundle\Tests\TestKernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+        <server name="SHELL_VERBOSITY" value="-1" />
     </php>
 </phpunit>

--- a/src/Batch.php
+++ b/src/Batch.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Jwage\PhpAmqpLibMessengerBundle;
 
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferable;
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Defered;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferrable;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferred;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\BatchTransportInterface;
 use Override;
 use Symfony\Component\Messenger\Envelope;
@@ -32,11 +32,11 @@ class Batch implements MessageBusInterface
     public function dispatch(object $message, array $stamps = []): Envelope
     {
         $envelope = Envelope::wrap($message)
-            ->with(new Deferable($this->batchSize));
+            ->with(new Deferrable($this->batchSize));
 
         $envelope = $this->wrappedBus->dispatch($envelope);
 
-        if (($stamp = $envelope->last(Defered::class)) !== null) {
+        if (($stamp = $envelope->last(Deferred::class)) !== null) {
             $this->transportsToFlush[] = $stamp->getTransport();
         }
 

--- a/src/Middleware/AmqpFlushMiddlware.php
+++ b/src/Middleware/AmqpFlushMiddlware.php
@@ -8,20 +8,29 @@ use Jwage\PhpAmqpLibMessengerBundle\Transport\BatchTransportInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Stamp\SentStamp;
+use Symfony\Component\Messenger\Transport\Sender\SendersLocatorInterface;
 
 final class AmqpFlushMiddlware implements MiddlewareInterface
 {
     /** @var array<BatchTransportInterface> */
     private array $transportsToFlush = [];
 
-    public function __construct()
+    public function __construct(
+        private SendersLocatorInterface $sendersLocator,
+    )
     {
     }
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
         if ($envelope->getMessage() instanceof Flush) {
-            foreach ($this->transportsToFlush as $transport) {
-                $transport->flush();
+            foreach ($this->transportsToFlush as $envelope) {
+                foreach ($this->sendersLocator->getSenders($envelope) as $transport) {
+                    if (!$transport instanceof BatchTransportInterface) {
+                        continue;
+                    }
+                    $transport->flush();
+                }
             }
             return $envelope;
         }
@@ -30,8 +39,9 @@ final class AmqpFlushMiddlware implements MiddlewareInterface
         $envelope = $stack->next()->handle($envelope, $stack);
 
         if (($stamp = $envelope->last(Deferred::class)) !== null) {
-            $transport = $stamp->getTransport();
-            $this->transportsToFlush[] = $transport;
+            if (($sent = $envelope->last(SentStamp::class))) {
+                $this->transportsToFlush[$sent->getSenderAlias()] = $envelope;
+            }
         }
 
         return $envelope;

--- a/src/Middleware/AmqpFlushMiddlware.php
+++ b/src/Middleware/AmqpFlushMiddlware.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Jwage\PhpAmqpLibMessengerBundle\Middleware;
 
 use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferred;
@@ -18,23 +20,24 @@ final class AmqpFlushMiddlware implements MiddlewareInterface
 
     public function __construct(
         private SendersLocatorInterface $sendersLocator,
-    )
-    {
+    ) {
     }
+
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
         if ($envelope->getMessage() instanceof Flush) {
             foreach ($this->transportsToFlush as $envelope) {
                 foreach ($this->sendersLocator->getSenders($envelope) as $transport) {
-                    if (!$transport instanceof BatchTransportInterface) {
+                    if (! $transport instanceof BatchTransportInterface) {
                         continue;
                     }
+
                     $transport->flush();
                 }
             }
+
             return $envelope;
         }
-
 
         $envelope = $stack->next()->handle($envelope, $stack);
 

--- a/src/Middleware/AmqpFlushMiddlware.php
+++ b/src/Middleware/AmqpFlushMiddlware.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Jwage\PhpAmqpLibMessengerBundle\Middleware;
+
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferred;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\Flush;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\BatchTransportInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+
+final class AmqpFlushMiddlware implements MiddlewareInterface
+{
+    /** @var array<BatchTransportInterface> */
+    private array $transportsToFlush = [];
+
+    public function __construct()
+    {
+    }
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        if ($envelope->getMessage() instanceof Flush) {
+            foreach ($this->transportsToFlush as $transport) {
+                $transport->flush();
+            }
+            return $envelope;
+        }
+
+
+        $envelope = $stack->next()->handle($envelope, $stack);
+
+        if (($stamp = $envelope->last(Deferred::class)) !== null) {
+            $transport = $stamp->getTransport();
+            $this->transportsToFlush[] = $transport;
+        }
+
+        return $envelope;
+    }
+}

--- a/src/Stamp/Deferrable.php
+++ b/src/Stamp/Deferrable.php
@@ -6,7 +6,7 @@ namespace Jwage\PhpAmqpLibMessengerBundle\Stamp;
 
 use Symfony\Component\Messenger\Stamp\StampInterface;
 
-class Deferable implements StampInterface
+class Deferrable implements StampInterface
 {
     public function __construct(
         private int $batchSize,

--- a/src/Stamp/Deferred.php
+++ b/src/Stamp/Deferred.php
@@ -4,18 +4,8 @@ declare(strict_types=1);
 
 namespace Jwage\PhpAmqpLibMessengerBundle\Stamp;
 
-use Jwage\PhpAmqpLibMessengerBundle\Transport\BatchTransportInterface;
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 
-class Deferred implements NonSendableStampInterface
+final class Deferred implements NonSendableStampInterface
 {
-    public function __construct(
-        private BatchTransportInterface $transport,
-    ) {
-    }
-
-    public function getTransport(): BatchTransportInterface
-    {
-        return $this->transport;
-    }
 }

--- a/src/Stamp/Deferred.php
+++ b/src/Stamp/Deferred.php
@@ -7,7 +7,7 @@ namespace Jwage\PhpAmqpLibMessengerBundle\Stamp;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\BatchTransportInterface;
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 
-class Defered implements NonSendableStampInterface
+class Deferred implements NonSendableStampInterface
 {
     public function __construct(
         private BatchTransportInterface $transport,

--- a/src/Stamp/Flush.php
+++ b/src/Stamp/Flush.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Jwage\PhpAmqpLibMessengerBundle\Stamp;
+
+final class Flush
+{
+}

--- a/src/Stamp/Flush.php
+++ b/src/Stamp/Flush.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Jwage\PhpAmqpLibMessengerBundle\Stamp;
 
 final class Flush

--- a/src/Transport/AmqpSender.php
+++ b/src/Transport/AmqpSender.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jwage\PhpAmqpLibMessengerBundle\Transport;
 
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferable;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferrable;
 use Override;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\TransportException;
@@ -35,8 +35,8 @@ class AmqpSender implements SenderInterface, BatchSenderInterface
     {
         $encodedMessage = $this->serializer->encode($envelope);
 
-        $deferable = $envelope->last(Deferable::class);
-        $batchSize = $deferable ? $deferable->getBatchSize() : 1;
+        $deferrable = $envelope->last(Deferrable::class);
+        $batchSize  = $deferrable ? $deferrable->getBatchSize() : 1;
 
         $delayStamp = $envelope->last(DelayStamp::class);
         $delay      = $delayStamp ? $delayStamp->getDelay() : 0;

--- a/src/Transport/AmqpTransport.php
+++ b/src/Transport/AmqpTransport.php
@@ -78,7 +78,7 @@ class AmqpTransport implements QueueReceiverInterface, MessageCountAwareInterfac
     public function send(Envelope $envelope): Envelope
     {
         if ($envelope->last(Deferrable::class) !== null) {
-            $envelope = $envelope->with(new Deferred($this));
+            $envelope = $envelope->with(new Deferred());
         }
 
         return $this->getSender()->send($envelope);

--- a/src/Transport/AmqpTransport.php
+++ b/src/Transport/AmqpTransport.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Jwage\PhpAmqpLibMessengerBundle\Transport;
 
 use InvalidArgumentException;
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferable;
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Defered;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferrable;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferred;
 use Override;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\TransportException;
@@ -77,8 +77,8 @@ class AmqpTransport implements QueueReceiverInterface, MessageCountAwareInterfac
     #[Override]
     public function send(Envelope $envelope): Envelope
     {
-        if ($envelope->last(Deferable::class) !== null) {
-            $envelope = $envelope->with(new Defered($this));
+        if ($envelope->last(Deferrable::class) !== null) {
+            $envelope = $envelope->with(new Deferred($this));
         }
 
         return $this->getSender()->send($envelope);

--- a/tests/BatchMessageBusTest.php
+++ b/tests/BatchMessageBusTest.php
@@ -33,7 +33,7 @@ class BatchMessageBusTest extends TestCase
 
         $this->wrappedBus->dispatch($message, $stamps);
 
-        $last = $this->wrappedBus->getLastDispatched();
+        $last = $this->wrappedBus->popEnvelope();
         self::assertEquals(
             new Envelope($message, $stamps),
             $last

--- a/tests/BatchMessageBusTest.php
+++ b/tests/BatchMessageBusTest.php
@@ -6,10 +6,8 @@ namespace Jwage\PhpAmqpLibMessengerBundle\Tests;
 
 use Jwage\PhpAmqpLibMessengerBundle\Batch;
 use Jwage\PhpAmqpLibMessengerBundle\BatchMessageBus;
-use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
 
 class BatchMessageBusTest extends TestCase
@@ -36,7 +34,7 @@ class BatchMessageBusTest extends TestCase
         $last = $this->wrappedBus->popEnvelope();
         self::assertEquals(
             new Envelope($message, $stamps),
-            $last
+            $last,
         );
     }
 

--- a/tests/BatchTest.php
+++ b/tests/BatchTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Jwage\PhpAmqpLibMessengerBundle\Tests;
 
 use Jwage\PhpAmqpLibMessengerBundle\Batch;
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferable;
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Defered;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferrable;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferred;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\BatchTransportInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
@@ -32,12 +32,12 @@ class BatchTest extends TestCase
         $message2 = new stdClass();
 
         $envelope1 = Envelope::wrap($message1)
-            ->with(new Deferable(10))
-            ->with(new Defered($this->transport1));
+            ->with(new Deferrable(10))
+            ->with(new Deferred($this->transport1));
 
         $envelope2 = Envelope::wrap($message2)
-            ->with(new Deferable(10))
-            ->with(new Defered($this->transport2));
+            ->with(new Deferrable(10))
+            ->with(new Deferred($this->transport2));
 
         $this->wrappedBus->expects(self::exactly(2))
             ->method('dispatch')

--- a/tests/TestKernel.php
+++ b/tests/TestKernel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Jwage\PhpAmqpLibMessengerBundle\Tests;
 
+use Jwage\PhpAmqpLibMessengerBundle\Middleware\AmqpFlushMiddlware;
 use Jwage\PhpAmqpLibMessengerBundle\PhpAmqpLibMessengerBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
@@ -48,7 +49,11 @@ class TestKernel extends Kernel implements CompilerPassInterface
                 'messenger' => [
                     'default_bus' => 'bus1',
                     'buses' => [
-                        'bus1' => [],
+                        'bus1' => [
+                            'middleware' => [
+                                AmqpFlushMiddlware::class => [],
+                            ],
+                        ],
                         'bus2' => [],
                     ],
                     'transports' => [

--- a/tests/Transport/AmqpSenderTest.php
+++ b/tests/Transport/AmqpSenderTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jwage\PhpAmqpLibMessengerBundle\Tests\Transport;
 
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferable;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferrable;
 use Jwage\PhpAmqpLibMessengerBundle\Tests\TestCase;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpEnvelope;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpReceivedStamp;
@@ -32,7 +32,7 @@ class AmqpSenderTest extends TestCase
     {
         $amqpEnvelope = new AmqpEnvelope(new AMQPMessage('test'));
 
-        $deferableStamp = new Deferable(1);
+        $deferrableStamp = new Deferrable(1);
 
         $delayStamp = new DelayStamp(1000);
 
@@ -57,7 +57,7 @@ class AmqpSenderTest extends TestCase
 
         $message  = new stdClass();
         $envelope = new Envelope($message, [
-            $deferableStamp,
+            $deferrableStamp,
             $delayStamp,
             $amqpStamp,
             $amqpReceivedStamp,

--- a/tests/TransportFunctionalTest.php
+++ b/tests/TransportFunctionalTest.php
@@ -52,6 +52,13 @@ class TransportFunctionalTest extends KernelTestCase
         $transport = $container->get('messenger.transport.test_phpamqplib');
         assert($transport instanceof AmqpTransport);
 
+        // "purge" the queues
+        foreach ($transport->getConnection()->getQueueNames() as $queue) {
+            foreach ($transport->getConnection()->get($queue) as $message) {
+                $message->ack();
+            }
+        }
+
         $this->transport = $transport;
     }
 

--- a/tests/WrappedBus.php
+++ b/tests/WrappedBus.php
@@ -5,21 +5,31 @@ declare(strict_types=1);
 namespace Jwage\PhpAmqpLibMessengerBundle\Tests;
 
 use Override;
+use RuntimeException;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 class WrappedBus implements MessageBusInterface
 {
-    public function __construct(
-        private MessageBusInterface $wrappedBus,
-    ) {
-    }
+    public array $dispatched = [];
 
     /** @inheritDoc */
     #[Override]
     public function dispatch(object $message, array $stamps = []): Envelope
     {
-        return $this->wrappedBus->dispatch($message, $stamps);
+        $envelope = (new Envelope($message))->with(...$stamps);
+        $this->dispatched[] = $envelope;
+        return $envelope;
+
+    }
+
+    public function getLastDispatched(): Envelope
+    {
+        if (empty($this->dispatched)) {
+            throw new RuntimeException('No envelopes in dispatched stack');
+        }
+
+        return array_pop($this->dispatched);
     }
 
     public function someMethod(string $arg1, string $arg2): string

--- a/tests/WrappedBus.php
+++ b/tests/WrappedBus.php
@@ -17,13 +17,15 @@ class WrappedBus implements MessageBusInterface
     #[Override]
     public function dispatch(object $message, array $stamps = []): Envelope
     {
-        $envelope = (new Envelope($message))->with(...$stamps);
-        $this->dispatched[] = $envelope;
-        return $envelope;
+        if (!$message instanceof Envelope) {
+            $message = (new Envelope($message))->with(...$stamps);
+        }
+        $this->dispatched[] = $message;
+        return $message;
 
     }
 
-    public function getLastDispatched(): Envelope
+    public function popEnvelope(): Envelope
     {
         if (empty($this->dispatched)) {
             throw new RuntimeException('No envelopes in dispatched stack');

--- a/tests/WrappedBus.php
+++ b/tests/WrappedBus.php
@@ -9,20 +9,26 @@ use RuntimeException;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
+use function array_pop;
+
 class WrappedBus implements MessageBusInterface
 {
+    /**
+     * @var Envelope
+     */
     public array $dispatched = [];
 
     /** @inheritDoc */
     #[Override]
     public function dispatch(object $message, array $stamps = []): Envelope
     {
-        if (!$message instanceof Envelope) {
+        if (! $message instanceof Envelope) {
             $message = (new Envelope($message))->with(...$stamps);
         }
-        $this->dispatched[] = $message;
-        return $message;
 
+        $this->dispatched[] = $message;
+
+        return $message;
     }
 
     public function popEnvelope(): Envelope

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\ErrorHandler\ErrorHandler;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+set_exception_handler([new ErrorHandler(), 'handleException']);


### PR DESCRIPTION
(includes the other two merge requests as the first two commits which I'll rebase away later)

This PR refactors the internals to flush via. a `Flush` message while preserving the external API - this approach makes it possible to use batching _without_ the `BatchMessageBus` while preserving the `BatchMessageBus` as an easier-to-use Facade:

```php
$batch = $batchMessageBus->getBatch(10);
for ($i = 0; $i < 100; $i++) {
    $batch->dispatch($message);
}
$batch->flush();

// can now alternatively be done on ANY bus:

for ($i = 0; $i < 100; $i++) {
  $someRandomBus->dispatch(new Envelope($message), [new Deferred(batchSize: 10)]);
}
$someRandomBus->dispatch(Flush::class);
```

It:

- **Introduces a Flush middleware**: Responsible both for flushing the transports and recording the transports messages were sent to.
- **Updates Batch**: Updates the `Batch` class to use the bus (the responsiblity for tracking the messages is now shifted to the middleware).
- **Could require user configuration**: Currently requires that the middlware is manually added - we could do this automatically but I'm unsure if that's wise.

Additionally:

- Ensures we only flush once per transport.
- "Purges" the queues on setup in the functional test.
- Makes the `WrappedBus` a test implementation that replaces the Mock (trying to understand the error messages from phpunit took more time than it did to swap in a real implementation :sweat_smile: )

Danger:

- If the `AmqpFlushMiddleware` is not registered then `flush()` will result in `No handler for message "Jwage\PhpAmqpLibMessengerBundle\Stamp\Flush` - which is better than nothing..

> [!NOTE]
> this is a draft - if we think it's the way forward I'll continue with it and flesh out the tests etc :)
