### PR TITLE
Use the Stamp suffix as with Symfony

### DIFF
--- a/src/Batch.php
+++ b/src/Batch.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Jwage\PhpAmqpLibMessengerBundle;
 
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferrable;
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferred;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\DeferrableStamp;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\DeferredStamp;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\BatchTransportInterface;
 use Override;
 use Symfony\Component\Messenger\Envelope;
@@ -32,11 +32,11 @@ class Batch implements MessageBusInterface
     public function dispatch(object $message, array $stamps = []): Envelope
     {
         $envelope = Envelope::wrap($message)
-            ->with(new Deferrable($this->batchSize));
+            ->with(new DeferrableStamp($this->batchSize));
 
         $envelope = $this->wrappedBus->dispatch($envelope);
 
-        if (($stamp = $envelope->last(Deferred::class)) !== null) {
+        if (($stamp = $envelope->last(DeferredStamp::class)) !== null) {
             $this->transportsToFlush[] = $stamp->getTransport();
         }
 

--- a/src/Stamp/DeferrableStamp.php
+++ b/src/Stamp/DeferrableStamp.php
@@ -6,7 +6,7 @@ namespace Jwage\PhpAmqpLibMessengerBundle\Stamp;
 
 use Symfony\Component\Messenger\Stamp\StampInterface;
 
-class Deferrable implements StampInterface
+class DeferrableStamp implements StampInterface
 {
     public function __construct(
         private int $batchSize,

--- a/src/Stamp/DeferredStamp.php
+++ b/src/Stamp/DeferredStamp.php
@@ -7,7 +7,7 @@ namespace Jwage\PhpAmqpLibMessengerBundle\Stamp;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\BatchTransportInterface;
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 
-class Deferred implements NonSendableStampInterface
+class DeferredStamp implements NonSendableStampInterface
 {
     public function __construct(
         private BatchTransportInterface $transport,

--- a/src/Transport/AmqpSender.php
+++ b/src/Transport/AmqpSender.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jwage\PhpAmqpLibMessengerBundle\Transport;
 
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferrable;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\DeferrableStamp;
 use Override;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\TransportException;
@@ -35,7 +35,7 @@ class AmqpSender implements SenderInterface, BatchSenderInterface
     {
         $encodedMessage = $this->serializer->encode($envelope);
 
-        $deferrable = $envelope->last(Deferrable::class);
+        $deferrable = $envelope->last(DeferrableStamp::class);
         $batchSize  = $deferrable ? $deferrable->getBatchSize() : 1;
 
         $delayStamp = $envelope->last(DelayStamp::class);

--- a/src/Transport/AmqpTransport.php
+++ b/src/Transport/AmqpTransport.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Jwage\PhpAmqpLibMessengerBundle\Transport;
 
 use InvalidArgumentException;
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferrable;
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferred;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\DeferrableStamp;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\DeferredStamp;
 use Override;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\TransportException;
@@ -77,8 +77,8 @@ class AmqpTransport implements QueueReceiverInterface, MessageCountAwareInterfac
     #[Override]
     public function send(Envelope $envelope): Envelope
     {
-        if ($envelope->last(Deferrable::class) !== null) {
-            $envelope = $envelope->with(new Deferred($this));
+        if ($envelope->last(DeferrableStamp::class) !== null) {
+            $envelope = $envelope->with(new DeferredStamp($this));
         }
 
         return $this->getSender()->send($envelope);

--- a/tests/BatchTest.php
+++ b/tests/BatchTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Jwage\PhpAmqpLibMessengerBundle\Tests;
 
 use Jwage\PhpAmqpLibMessengerBundle\Batch;
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferrable;
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferred;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\DeferrableStamp;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\DeferredStamp;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\BatchTransportInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
@@ -32,12 +32,12 @@ class BatchTest extends TestCase
         $message2 = new stdClass();
 
         $envelope1 = Envelope::wrap($message1)
-            ->with(new Deferrable(10))
-            ->with(new Deferred($this->transport1));
+            ->with(new DeferrableStamp(10))
+            ->with(new DeferredStamp($this->transport1));
 
         $envelope2 = Envelope::wrap($message2)
-            ->with(new Deferrable(10))
-            ->with(new Deferred($this->transport2));
+            ->with(new DeferrableStamp(10))
+            ->with(new DeferredStamp($this->transport2));
 
         $this->wrappedBus->expects(self::exactly(2))
             ->method('dispatch')

--- a/tests/Transport/AmqpSenderTest.php
+++ b/tests/Transport/AmqpSenderTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Jwage\PhpAmqpLibMessengerBundle\Tests\Transport;
 
-use Jwage\PhpAmqpLibMessengerBundle\Stamp\Deferrable;
+use Jwage\PhpAmqpLibMessengerBundle\Stamp\DeferrableStamp;
 use Jwage\PhpAmqpLibMessengerBundle\Tests\TestCase;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpEnvelope;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpReceivedStamp;
@@ -35,7 +35,7 @@ class AmqpSenderTest extends TestCase
             'application_headers' => new AMQPTable(['header1' => 'value1', 'header2' => 'value2']),
         ]));
 
-        $deferrableStamp = new Deferrable(1);
+        $deferrableStamp = new DeferrableStamp(1);
 
         $delayStamp = new DelayStamp(1000);
 


### PR DESCRIPTION
Use the Stamp suffix to align with Symfony:

![image](https://github.com/user-attachments/assets/4bd52aa2-dfcc-4e5d-b8a1-21fb7c6766d0)
