### PR TITLE
Refactor consuming to try and fix performance issues.

### DIFF
--- a/src/Transport/AmqpReceiver.php
+++ b/src/Transport/AmqpReceiver.php
@@ -94,7 +94,7 @@ class AmqpReceiver implements QueueReceiverInterface, MessageCountAwareInterface
      */
     private function getEnvelopes(string $queueName): iterable
     {
-        $amqpEnvelopes = $this->connection->get($queueName);
+        $amqpEnvelopes = $this->connection->consume($queueName);
 
         foreach ($amqpEnvelopes as $amqpEnvelope) {
             $body = $amqpEnvelope->getBody();

--- a/src/Transport/Connection.php
+++ b/src/Transport/Connection.php
@@ -103,22 +103,17 @@ class Connection
     }
 
     /**
-     * @return array<AmqpEnvelope>
+     * @return iterable<AmqpEnvelope>
      *
      * @throws AMQPExceptionInterface
      * @throws TransportException
      * @throws InvalidArgumentException
      */
-    public function get(string $queueName): array
+    public function consume(string $queueName): iterable
     {
         $this->setupExchangeAndQueues();
 
-        /** @var array<AmqpEnvelope> $amqpEnvelopes */
-        $amqpEnvelopes = $this->withRetry(function () use ($queueName): array {
-            return ($this->consumer ??= new AmqpConsumer($this, $this->connectionConfig))->get($queueName);
-        })->run();
-
-        return $amqpEnvelopes;
+        return ($this->consumer ??= new AmqpConsumer($this, $this->connectionConfig))->consume($queueName);
     }
 
     /**

--- a/tests/Transport/AmqpReceiverTest.php
+++ b/tests/Transport/AmqpReceiverTest.php
@@ -49,7 +49,7 @@ class AmqpReceiverTest extends TestCase
             ->willReturn(['queue_name']);
 
         $this->connection->expects(self::once())
-            ->method('get')
+            ->method('consume')
             ->willReturn([$amqpEnvelope]);
 
         $this->serializer->expects(self::once())
@@ -130,7 +130,7 @@ class AmqpReceiverTest extends TestCase
         $connectionConfig      = new ConnectionConfig();
 
         $this->connection = $this->getMockBuilder(Connection::class)
-            ->onlyMethods(['getQueueNames', 'get', 'countMessagesInQueues'])
+            ->onlyMethods(['getQueueNames', 'consume', 'countMessagesInQueues'])
             ->setConstructorArgs([$this->retryFactory, $amqpConnectionFactory, $connectionConfig])
             ->getMock();
 

--- a/tests/Transport/ConnectionTest.php
+++ b/tests/Transport/ConnectionTest.php
@@ -158,7 +158,7 @@ class ConnectionTest extends TestCase
     public function testGet(): void
     {
         /** @var Traversable<AMQPEnvelope> $amqpEnvelopes */
-        $amqpEnvelopes = $this->connection->get('queue_name');
+        $amqpEnvelopes = $this->connection->consume('queue_name');
 
         self::assertCount(0, iterator_to_array($amqpEnvelopes));
     }


### PR DESCRIPTION
Not 100% if this is the cause of the performance problems, but I want to test it.

I think this change also breaks the retry functionality on consume since we are passing generators all the way through to the Symfony worker loop so the code doesn't start actually executing until the worker starts looping over the generator.

I will need to revisit the retries there after this.