### PR TITLE
Wait for exchange, queue and bindings to be declared before publishing.

### DIFF
--- a/src/Transport/Connection.php
+++ b/src/Transport/Connection.php
@@ -334,7 +334,7 @@ class Connection
             passive: $this->connectionConfig->exchange->passive,
             durable: $this->connectionConfig->exchange->durable,
             auto_delete: $this->connectionConfig->exchange->autoDelete,
-            nowait: true,
+            nowait: false,
             arguments: new AMQPTable($this->connectionConfig->exchange->arguments),
         );
     }
@@ -357,7 +357,7 @@ class Connection
                 queue: $queueConfig->name,
                 exchange: $this->connectionConfig->exchange->name,
                 routing_key: $bindingConfig?->routingKey ?? '',
-                nowait: true,
+                nowait: false,
                 arguments: new AMQPTable($bindingConfig?->arguments ?? []),
             );
         }
@@ -374,7 +374,7 @@ class Connection
             durable: $queueConfig->durable,
             exclusive: $queueConfig->exclusive,
             auto_delete: $queueConfig->autoDelete,
-            nowait: true,
+            nowait: false,
             arguments: new AMQPTable($queueConfig->arguments),
         ) ?? [$queueName, 0];
 
@@ -404,7 +404,7 @@ class Connection
                 passive: $this->connectionConfig->delay->exchange->passive,
                 durable: $this->connectionConfig->delay->exchange->durable,
                 auto_delete: $this->connectionConfig->delay->exchange->autoDelete,
-                nowait: true,
+                nowait: false,
                 arguments: new AMQPTable($this->connectionConfig->delay->exchange->arguments),
             );
 
@@ -423,7 +423,7 @@ class Connection
 
             $this->channel()->queue_declare(
                 queue: $delayQueueName,
-                nowait: true,
+                nowait: false,
                 arguments: new AMQPTable([
                     'x-message-ttl' => $delay,
                     'x-expires' => $delay + 10000,
@@ -436,7 +436,7 @@ class Connection
                 queue: $delayQueueName,
                 exchange: $this->connectionConfig->delay->exchange->name,
                 routing_key: $delayQueueName,
-                nowait: true,
+                nowait: false,
             );
         } catch (AMQPExceptionInterface $e) {
             throw new TransportException($e->getMessage(), 0, $e);

--- a/tests/Transport/ConnectionTest.php
+++ b/tests/Transport/ConnectionTest.php
@@ -72,7 +72,7 @@ class ConnectionTest extends TestCase
                     true,
                     false,
                     false,
-                    true,
+                    false,
                     new AMQPTable([]),
                 ],
                 [
@@ -82,7 +82,7 @@ class ConnectionTest extends TestCase
                     true,
                     false,
                     false,
-                    true,
+                    false,
                     new AMQPTable([]),
                 ],
             ));
@@ -95,7 +95,7 @@ class ConnectionTest extends TestCase
                 durable: true,
                 exclusive: false,
                 auto_delete: false,
-                nowait: true,
+                nowait: false,
                 arguments: new AMQPTable([]),
             );
 
@@ -105,7 +105,7 @@ class ConnectionTest extends TestCase
                 queue: 'queue_name',
                 exchange: 'exchange_name',
                 routing_key: 'routing_key',
-                nowait: true,
+                nowait: false,
                 arguments: new AMQPTable(['arg1' => 'value1', 'arg2' => 'value2']),
             );
 
@@ -140,7 +140,7 @@ class ConnectionTest extends TestCase
                     true,
                     false,
                     false,
-                    true,
+                    false,
                     new AMQPTable([]),
                 ],
                 [
@@ -150,7 +150,7 @@ class ConnectionTest extends TestCase
                     true,
                     false,
                     false,
-                    true,
+                    false,
                     new AMQPTable([]),
                 ],
             ));
@@ -163,7 +163,7 @@ class ConnectionTest extends TestCase
                 durable: true,
                 exclusive: false,
                 auto_delete: false,
-                nowait: true,
+                nowait: false,
                 arguments: new AMQPTable([]),
             );
 
@@ -173,7 +173,7 @@ class ConnectionTest extends TestCase
                 queue: 'queue_name',
                 exchange: 'exchange_name',
                 routing_key: 'routing_key',
-                nowait: true,
+                nowait: false,
                 arguments: new AMQPTable(['arg1' => 'value1', 'arg2' => 'value2']),
             );
 
@@ -197,7 +197,7 @@ class ConnectionTest extends TestCase
                     true,
                     false,
                     false,
-                    true,
+                    false,
                     new AMQPTable([]),
                 ],
             ));


### PR DESCRIPTION
If we don't wait, then we have race conditions where the queue may not exist yet when we go to try and publish to it.