### PR TITLE
Implement connection caching so we don't create multiple of the same connection for different transports.

### DIFF
--- a/src/Transport/AmqpConnectionFactory.php
+++ b/src/Transport/AmqpConnectionFactory.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Jwage\PhpAmqpLibMessengerBundle\Transport;
 
 use Jwage\PhpAmqpLibMessengerBundle\Transport\Config\ConnectionConfig;
-use PhpAmqpLib\Connection\AMQPConnectionConfig;
 use PhpAmqpLib\Connection\AMQPConnectionFactory as BaseAMQPConnectionFactory;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 
@@ -15,66 +14,7 @@ class AmqpConnectionFactory
 {
     public function create(ConnectionConfig $connectionConfig): AMQPStreamConnection
     {
-        $config = new AMQPConnectionConfig();
-        $config->setIsLazy(true);
-        $config->setHost($connectionConfig->host);
-        $config->setPort($connectionConfig->port);
-        $config->setUser($connectionConfig->user);
-        $config->setPassword($connectionConfig->password);
-        $config->setVhost($connectionConfig->vhost);
-        $config->setInsist($connectionConfig->insist);
-        $config->setLoginMethod($connectionConfig->loginMethod);
-        $config->setLocale($connectionConfig->locale);
-        $config->setConnectionTimeout($connectionConfig->connectTimeout);
-        $config->setReadTimeout($connectionConfig->readTimeout);
-        $config->setWriteTimeout($connectionConfig->writeTimeout);
-        $config->setChannelRPCTimeout($connectionConfig->rpcTimeout);
-        $config->setHeartbeat($connectionConfig->heartbeat);
-        $config->setKeepalive($connectionConfig->keepalive);
-
-        if ($connectionConfig->ssl !== null) {
-            $config->setIsSecure(true);
-
-            if ($connectionConfig->ssl->cafile !== null) {
-                $config->setSslCaCert($connectionConfig->ssl->cafile);
-            }
-
-            if ($connectionConfig->ssl->capath !== null) {
-                $config->setSslCaPath($connectionConfig->ssl->capath);
-            }
-
-            if ($connectionConfig->ssl->localCert !== null) {
-                $config->setSslCert($connectionConfig->ssl->localCert);
-            }
-
-            if ($connectionConfig->ssl->localPk !== null) {
-                $config->setSslKey($connectionConfig->ssl->localPk);
-            }
-
-            if ($connectionConfig->ssl->verifyPeer !== null) {
-                $config->setSslVerify($connectionConfig->ssl->verifyPeer);
-            }
-
-            if ($connectionConfig->ssl->verifyPeerName !== null) {
-                $config->setSslVerifyName($connectionConfig->ssl->verifyPeerName);
-            }
-
-            if ($connectionConfig->ssl->passphrase !== null) {
-                $config->setSslPassPhrase($connectionConfig->ssl->passphrase);
-            }
-
-            if ($connectionConfig->ssl->ciphers !== null) {
-                $config->setSslCiphers($connectionConfig->ssl->ciphers);
-            }
-
-            if ($connectionConfig->ssl->securityLevel !== null) {
-                $config->setSslSecurityLevel($connectionConfig->ssl->securityLevel);
-            }
-
-            if ($connectionConfig->ssl->cryptoMethod !== null) {
-                $config->setSslCryptoMethod($connectionConfig->ssl->cryptoMethod);
-            }
-        }
+        $config = $connectionConfig->getAMQPConnectionConfig();
 
         $connection = BaseAMQPConnectionFactory::create($config);
         assert($connection instanceof AMQPStreamConnection);

--- a/src/Transport/Config/ConnectionConfig.php
+++ b/src/Transport/Config/ConnectionConfig.php
@@ -10,6 +10,8 @@ use SensitiveParameter;
 
 use function array_keys;
 use function is_string;
+use function md5;
+use function serialize;
 use function sprintf;
 use function str_replace;
 
@@ -340,6 +342,77 @@ readonly class ConnectionConfig
             ],
             $this->delay->queueNamePattern,
         ) . $action;
+    }
+
+    public function getAMQPConnectionConfig(): AMQPConnectionConfig
+    {
+        $config = new AMQPConnectionConfig();
+        $config->setIsLazy(true);
+        $config->setHost($this->host);
+        $config->setPort($this->port);
+        $config->setUser($this->user);
+        $config->setPassword($this->password);
+        $config->setVhost($this->vhost);
+        $config->setInsist($this->insist);
+        $config->setLoginMethod($this->loginMethod);
+        $config->setLocale($this->locale);
+        $config->setConnectionTimeout($this->connectTimeout);
+        $config->setReadTimeout($this->readTimeout);
+        $config->setWriteTimeout($this->writeTimeout);
+        $config->setChannelRPCTimeout($this->rpcTimeout);
+        $config->setHeartbeat($this->heartbeat);
+        $config->setKeepalive($this->keepalive);
+
+        if ($this->ssl !== null) {
+            $config->setIsSecure(true);
+
+            if ($this->ssl->cafile !== null) {
+                $config->setSslCaCert($this->ssl->cafile);
+            }
+
+            if ($this->ssl->capath !== null) {
+                $config->setSslCaPath($this->ssl->capath);
+            }
+
+            if ($this->ssl->localCert !== null) {
+                $config->setSslCert($this->ssl->localCert);
+            }
+
+            if ($this->ssl->localPk !== null) {
+                $config->setSslKey($this->ssl->localPk);
+            }
+
+            if ($this->ssl->verifyPeer !== null) {
+                $config->setSslVerify($this->ssl->verifyPeer);
+            }
+
+            if ($this->ssl->verifyPeerName !== null) {
+                $config->setSslVerifyName($this->ssl->verifyPeerName);
+            }
+
+            if ($this->ssl->passphrase !== null) {
+                $config->setSslPassPhrase($this->ssl->passphrase);
+            }
+
+            if ($this->ssl->ciphers !== null) {
+                $config->setSslCiphers($this->ssl->ciphers);
+            }
+
+            if ($this->ssl->securityLevel !== null) {
+                $config->setSslSecurityLevel($this->ssl->securityLevel);
+            }
+
+            if ($this->ssl->cryptoMethod !== null) {
+                $config->setSslCryptoMethod($this->ssl->cryptoMethod);
+            }
+        }
+
+        return $config;
+    }
+
+    public function getHash(): string
+    {
+        return md5(serialize($this->getAMQPConnectionConfig()));
     }
 
     /**

--- a/src/Transport/ConnectionFactory.php
+++ b/src/Transport/ConnectionFactory.php
@@ -11,6 +11,9 @@ use SensitiveParameter;
 
 class ConnectionFactory
 {
+    /** @var array<string, Connection> */
+    private array $connections = [];
+
     public function __construct(
         private DsnParser $dsnParser,
         private RetryFactory $retryFactory,
@@ -29,10 +32,14 @@ class ConnectionFactory
         string $dsn,
         array $options = [],
     ): Connection {
-        return new Connection(
+        $connectionConfig = $this->dsnParser->parseDsn($dsn, $options);
+
+        $connectionHash = $connectionConfig->getHash();
+
+        return $this->connections[$connectionHash] ??= new Connection(
             $this->retryFactory,
             $this->amqpConnectionFactory,
-            $this->dsnParser->parseDsn($dsn, $options),
+            $connectionConfig,
             $this->logger,
         );
     }

--- a/tests/Transport/Config/ConnectionConfigTest.php
+++ b/tests/Transport/Config/ConnectionConfigTest.php
@@ -300,7 +300,7 @@ class ConnectionConfigTest extends TestCase
         new ConnectionConfig(transactionsEnabled: true, confirmEnabled: true);
     }
 
-    public function testGetQueueName(): void
+    public function testGetDelayQueueName(): void
     {
         $connectionConfig = new ConnectionConfig(
             exchange: new ExchangeConfig(name: 'my_queue_name'),
@@ -323,6 +323,59 @@ class ConnectionConfigTest extends TestCase
             routingKey: null,
             isRetryAttempt: false,
         ));
+    }
+
+    public function testGetHash(): void
+    {
+        $connectionConfig = new ConnectionConfig();
+
+        self::assertSame('05f85c5ae10ce5a52d553a80cf2ecc17', $connectionConfig->getHash());
+
+        $connectionConfig = ConnectionConfig::fromArray([
+            'auto_setup' => true,
+            'host' => 'example.com',
+            'port' => 5673,
+            'user' => 'admin',
+            'password' => 'admin123',
+            'vhost' => '/custom',
+            'insist' => false,
+            'login_method' => 'PLAIN',
+            'locale' => 'fr_FR',
+            'connect_timeout' => 5.0,
+            'read_timeout' => 4.0,
+            'write_timeout' => 4.0,
+            'rpc_timeout' => 4.0,
+            'heartbeat' => 10,
+            'keepalive' => false,
+            'prefetch_count' => 15,
+            'wait_timeout' => 2.0,
+            'confirm_enabled' => true,
+            'confirm_timeout' => 10.0,
+            'exchange' => [
+                'name' => 'custom_exchange',
+                'type' => 'fanout',
+                'durable' => false,
+                'auto_delete' => true,
+            ],
+            'delay' => [
+                'exchange' => [
+                    'name' => 'delay_exchange',
+                    'type' => 'direct',
+                ],
+            ],
+            'queues' => [
+                'queue1' => [
+                    'prefetch_count' => 20,
+                    'wait_timeout' => 3.0,
+                ],
+                'queue2' => [
+                    'prefetch_count' => 30,
+                    'wait_timeout' => 4.0,
+                ],
+            ],
+        ]);
+
+        self::assertSame('7933824aa9b09330f25625b8fd6e5bb5', $connectionConfig->getHash());
     }
 
     private static function assertDefaultConnectionConfig(ConnectionConfig $connectionConfig): void

--- a/tests/TransportFunctionalTest.php
+++ b/tests/TransportFunctionalTest.php
@@ -243,6 +243,14 @@ class TransportFunctionalTest extends KernelTestCase
         self::assertSame('expired', $amqpEnvelope->getHeader('x-last-death-reason'));
     }
 
+    public function testConnectionCaching(): void
+    {
+        self::assertSame(
+            $this->confirmsTransport->getConnection()->channel(),
+            $this->transactionsTransport->getConnection()->channel(),
+        );
+    }
+
     protected function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
fixes #91

This helps this scenario when someone runs `messenger:consume` with multiple transports.

```
bin/console messenger:consumer transport1 transport2
```

Right now if `transport1` and `transport2` have the same DSN, it'll create two connections for each transport and open up a separate channel for each transport connection. After this change, it'd share the same connection.