### PR TITLE
Improve retry mechanism for AMQPTimeoutException and wait_for_pending_acks()

### DIFF
--- a/src/RetryFactory.php
+++ b/src/RetryFactory.php
@@ -8,6 +8,7 @@ use Closure;
 use PhpAmqpLib\Exception\AMQPChannelClosedException;
 use PhpAmqpLib\Exception\AMQPConnectionClosedException;
 use PhpAmqpLib\Exception\AMQPIOException;
+use PhpAmqpLib\Exception\AMQPTimeoutException;
 use Psr\Log\LoggerInterface;
 
 class RetryFactory
@@ -30,6 +31,7 @@ class RetryFactory
                 AMQPChannelClosedException::class,
                 AMQPConnectionClosedException::class,
                 AMQPIOException::class,
+                AMQPTimeoutException::class,
             ]);
     }
 }

--- a/src/Transport/Connection.php
+++ b/src/Transport/Connection.php
@@ -234,7 +234,8 @@ class Connection
     /** @throws TransportException */
     public function flush(): void
     {
-        $this->retryWithReconnect(function (): void {
+        // We don't want to use retryWithReconnect() here because it needs to be retried on the same connection and channel
+        $this->retry(function (): void {
             if ($this->connectionConfig->transactionsEnabled) {
                 $this->channel()->tx_select();
             }


### PR DESCRIPTION
fixes #101

- Added `AMQPTimeoutException` to the list of exception types to retry.
- In the case of `flush()`, if we use `retryWithReconnect()`, it will create a new connection and channel, and it won't work because `wait_for_pending_acks()` is happening on a new connection/channel and the `batch_basic_publish()` happened on a different older connection.