### PR TITLE
Fix PHPUnit 12.5 deprecations

### DIFF
--- a/tests/BatchTest.php
+++ b/tests/BatchTest.php
@@ -18,31 +18,28 @@ class BatchTest extends TestCase
     /** @var MessageBusInterface&MockObject */
     private MessageBusInterface $wrappedBus;
 
-    /** @var BatchTransportInterface&MockObject */
-    private BatchTransportInterface $transport1;
-
-    /** @var BatchTransportInterface&MockObject */
-    private BatchTransportInterface $transport2;
-
     private Batch $batch;
 
     public function testDispatch(): void
     {
+        $transport1 = $this->createMock(BatchTransportInterface::class);
+        $transport2 = $this->createMock(BatchTransportInterface::class);
+
         $message1 = new stdClass();
         $message2 = new stdClass();
 
-        $envelope1 = $this->createEnvelope($message1, transport: $this->transport1);
-        $envelope2 = $this->createEnvelope($message2, transport: $this->transport2);
+        $envelope1 = $this->createEnvelope($message1, transport: $transport1);
+        $envelope2 = $this->createEnvelope($message2, transport: $transport2);
 
         $this->wrappedBus->expects(self::exactly(2))
             ->method('dispatch')
             ->with($this->isInstanceOf(Envelope::class))
             ->willReturnOnConsecutiveCalls($envelope1, $envelope2);
 
-        $this->transport1->expects(self::once())
+        $transport1->expects(self::once())
             ->method('flush');
 
-        $this->transport2->expects(self::once())
+        $transport2->expects(self::once())
             ->method('flush');
 
         $this->batch->dispatch($message1);
@@ -53,18 +50,20 @@ class BatchTest extends TestCase
 
     public function testFlushTransportOncePerBatch(): void
     {
+        $transport = $this->createMock(BatchTransportInterface::class);
+
         $message1 = new stdClass();
 
-        $envelope1 = $this->createEnvelope($message1);
-        $envelope2 = $this->createEnvelope($message1);
-        $envelope3 = $this->createEnvelope($message1);
+        $envelope1 = $this->createEnvelope($message1, transport: $transport);
+        $envelope2 = $this->createEnvelope($message1, transport: $transport);
+        $envelope3 = $this->createEnvelope($message1, transport: $transport);
 
         $this->wrappedBus->expects(self::exactly(3))
             ->method('dispatch')
             ->with($this->isInstanceOf(Envelope::class))
             ->willReturnOnConsecutiveCalls($envelope1, $envelope2, $envelope3);
 
-        $this->transport1->expects(self::once())
+        $transport->expects(self::once())
             ->method('flush');
 
         $this->batch->dispatch($message1);
@@ -76,20 +75,23 @@ class BatchTest extends TestCase
 
     public function testFlushEachTransportOnce(): void
     {
+        $transport1 = $this->createMock(BatchTransportInterface::class);
+        $transport2 = $this->createMock(BatchTransportInterface::class);
+
         $message1 = new stdClass();
 
-        $envelope1 = $this->createEnvelope($message1, transport: $this->transport1);
-        $envelope2 = $this->createEnvelope($message1, transport: $this->transport1);
-        $envelope3 = $this->createEnvelope($message1, transport: $this->transport2);
+        $envelope1 = $this->createEnvelope($message1, transport: $transport1);
+        $envelope2 = $this->createEnvelope($message1, transport: $transport1);
+        $envelope3 = $this->createEnvelope($message1, transport: $transport2);
 
         $this->wrappedBus->expects(self::exactly(3))
             ->method('dispatch')
             ->with($this->isInstanceOf(Envelope::class))
             ->willReturnOnConsecutiveCalls($envelope1, $envelope2, $envelope3);
 
-        $this->transport1->expects(self::exactly(1))
+        $transport1->expects(self::exactly(1))
             ->method('flush');
-        $this->transport1->expects(self::exactly(1))
+        $transport2->expects(self::exactly(1))
             ->method('flush');
 
         $this->batch->dispatch($message1);
@@ -115,10 +117,6 @@ class BatchTest extends TestCase
 
         $this->wrappedBus = $this->createMock(WrappedBus::class);
 
-        $this->transport1 = $this->createMock(BatchTransportInterface::class);
-
-        $this->transport2 = $this->createMock(BatchTransportInterface::class);
-
         $this->batch = new Batch($this->wrappedBus, 10);
     }
 
@@ -126,6 +124,6 @@ class BatchTest extends TestCase
     {
         return Envelope::wrap($message)
             ->with(new DeferrableStamp($batchSize))
-            ->with(new DeferredStamp($transport ?? $this->transport1));
+            ->with(new DeferredStamp($transport ?? $this->createStub(BatchTransportInterface::class)));
     }
 }

--- a/tests/Transport/AmqpConsumerTest.php
+++ b/tests/Transport/AmqpConsumerTest.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Jwage\PhpAmqpLibMessengerBundle\Tests\Transport;
 
 use Closure;
-use Jwage\PhpAmqpLibMessengerBundle\RetryFactory;
 use Jwage\PhpAmqpLibMessengerBundle\Tests\TestCase;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpConnectionFactory;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpConsumer;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpEnvelope;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\Config\ConnectionConfig;
@@ -17,7 +15,6 @@ use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Exception\AMQPProtocolChannelException;
 use PhpAmqpLib\Exception\AMQPTimeoutException;
 use PhpAmqpLib\Message\AMQPMessage;
-use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Traversable;
 
@@ -25,32 +22,19 @@ use function iterator_to_array;
 
 class AmqpConsumerTest extends TestCase
 {
-    /** @var MockObject&LoggerInterface */
-    private LoggerInterface $logger;
-
-    private RetryFactory $retryFactory;
-
-    /** @var MockObject&AmqpConnectionFactory */
-    private AmqpConnectionFactory $amqpConnectionFactory;
-
-    /** @var MockObject&Connection */
-    private Connection $connection;
-
     private ConnectionConfig $connectionConfig;
-
-    private AmqpConsumer $consumer;
 
     public function testConsume(): void
     {
         $channel = $this->createMock(AMQPChannel::class);
 
-        $this->connection->expects(self::any())
-            ->method('channel')
+        $connection = $this->createStub(Connection::class);
+        $connection->method('channel')
             ->willReturn($channel);
-
-        $this->connection->expects(self::any())
-            ->method('getQueueNames')
+        $connection->method('getQueueNames')
             ->willReturn(['test_queue']);
+
+        $consumer = $this->getTestConsumer(connection: $connection);
 
         $channel->expects(self::once())
             ->method('basic_qos')
@@ -87,16 +71,16 @@ class AmqpConsumerTest extends TestCase
             ->will($this->throwException(new AMQPTimeoutException()));
 
         /** @var Traversable<AMQPEnvelope> $amqpEnvelopes */
-        $amqpEnvelopes = $this->consumer->consume('test_queue');
+        $amqpEnvelopes = $consumer->consume('test_queue');
 
         self::assertCount(0, iterator_to_array($amqpEnvelopes));
 
-        $message = $this->createMock(AMQPMessage::class);
+        $message = $this->createStub(AMQPMessage::class);
 
-        $this->consumer->callback($message);
+        $consumer->callback($message);
 
         /** @var Traversable<AMQPEnvelope> $amqpEnvelopes */
-        $amqpEnvelopes = $this->consumer->consume('test_queue');
+        $amqpEnvelopes = $consumer->consume('test_queue');
 
         self::assertCount(1, iterator_to_array($amqpEnvelopes));
     }
@@ -105,13 +89,15 @@ class AmqpConsumerTest extends TestCase
     {
         $channel = $this->createMock(AMQPChannel::class);
 
-        $this->connection->expects(self::any())
-            ->method('channel')
+        $connection = $this->createMock(Connection::class);
+        $connection->method('channel')
             ->willReturn($channel);
-
-        $this->connection->expects(self::any())
-            ->method('getQueueNames')
+        $connection->method('getQueueNames')
             ->willReturn(['test_queue']);
+
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $consumer = $this->getTestConsumer(connection: $connection, logger: $logger);
 
         $channel->expects(self::once())
             ->method('basic_qos')
@@ -149,18 +135,18 @@ class AmqpConsumerTest extends TestCase
             )
             ->will($this->throwException($exception));
 
-        $this->logger->expects(self::once())
+        $logger->expects(self::once())
             ->method('warning')
             ->with(
                 'AMQP exception occurred while waiting for messages: {message}',
                 ['message' => 'Test', 'exception' => $exception],
             );
 
-        $this->connection->expects(self::once())
+        $connection->expects(self::once())
             ->method('close');
 
         /** @var Traversable<AMQPEnvelope> $amqpEnvelopes */
-        $amqpEnvelopes = $this->consumer->consume('test_queue');
+        $amqpEnvelopes = $consumer->consume('test_queue');
 
         self::assertCount(0, iterator_to_array($amqpEnvelopes));
     }
@@ -176,17 +162,15 @@ class AmqpConsumerTest extends TestCase
             ],
         ]);
 
-        $consumer = $this->getTestConsumer($connectionConfig);
-
         $channel = $this->createMock(AMQPChannel::class);
 
-        $this->connection->expects(self::any())
-            ->method('channel')
+        $connection = $this->createStub(Connection::class);
+        $connection->method('channel')
             ->willReturn($channel);
-
-        $this->connection->expects(self::any())
-            ->method('getQueueNames')
+        $connection->method('getQueueNames')
             ->willReturn(['test_queue']);
+
+        $consumer = $this->getTestConsumer(connectionConfig: $connectionConfig, connection: $connection);
 
         $channel->expects(self::once())
             ->method('basic_qos')
@@ -227,7 +211,7 @@ class AmqpConsumerTest extends TestCase
 
         self::assertCount(0, iterator_to_array($amqpEnvelopes));
 
-        $message = $this->createMock(AMQPMessage::class);
+        $message = $this->createStub(AMQPMessage::class);
 
         $consumer->callback($message);
 
@@ -241,13 +225,13 @@ class AmqpConsumerTest extends TestCase
     {
         $channel = $this->createMock(AMQPChannel::class);
 
-        $this->connection->expects(self::any())
-            ->method('channel')
+        $connection = $this->createStub(Connection::class);
+        $connection->method('channel')
             ->willReturn($channel);
-
-        $this->connection->expects(self::any())
-            ->method('getQueueNames')
+        $connection->method('getQueueNames')
             ->willReturn(['test_queue']);
+
+        $consumer = $this->getTestConsumer(connection: $connection);
 
         $channel->expects(self::once())
             ->method('basic_qos')
@@ -290,22 +274,16 @@ class AmqpConsumerTest extends TestCase
             );
 
         /** @var Traversable<AMQPEnvelope> $amqpEnvelopes */
-        $amqpEnvelopes = $this->consumer->consume('test_queue');
+        $amqpEnvelopes = $consumer->consume('test_queue');
 
         self::assertCount(0, iterator_to_array($amqpEnvelopes));
 
-        $this->consumer->stop();
+        $consumer->stop();
     }
 
     protected function setUp(): void
     {
         parent::setUp();
-
-        $this->logger = $this->createMock(LoggerInterface::class);
-
-        $this->retryFactory = new RetryFactory($this->logger);
-
-        $this->amqpConnectionFactory = $this->createMock(AmqpConnectionFactory::class);
 
         $this->connectionConfig = new ConnectionConfig(
             queues: [
@@ -316,27 +294,17 @@ class AmqpConsumerTest extends TestCase
                 ),
             ],
         );
-
-        $this->connection = $this->getTestConnection();
-
-        $this->consumer = $this->getTestConsumer();
     }
 
-    private function getTestConsumer(ConnectionConfig|null $connectionConfig = null): AmqpConsumer
-    {
-        return new AmqpConsumer($this->connection, $connectionConfig ?? $this->connectionConfig, $this->logger);
-    }
-
-    private function getTestConnection(ConnectionConfig|null $connectionConfig = null): Connection&MockObject
-    {
-        return $this->getMockBuilder(Connection::class)
-            ->onlyMethods(['channel', 'getQueueNames', 'close'])
-            ->setConstructorArgs([
-                $this->retryFactory,
-                $this->amqpConnectionFactory,
-                $connectionConfig ?? $this->connectionConfig,
-                $this->logger,
-            ])
-            ->getMock();
+    private function getTestConsumer(
+        ConnectionConfig|null $connectionConfig = null,
+        Connection|null $connection = null,
+        LoggerInterface|null $logger = null,
+    ): AmqpConsumer {
+        return new AmqpConsumer(
+            $connection ?? $this->createStub(Connection::class),
+            $connectionConfig ?? $this->connectionConfig,
+            $logger ?? $this->createStub(LoggerInterface::class),
+        );
     }
 }

--- a/tests/Transport/AmqpEnvelopeTest.php
+++ b/tests/Transport/AmqpEnvelopeTest.php
@@ -13,218 +13,266 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 class AmqpEnvelopeTest extends TestCase
 {
-    /** @var MockObject&AMQPMessage */
-    private AMQPMessage $message;
+    /** @return array{AMQPMessage&MockObject, AmqpEnvelope} */
+    private function createMockEnvelope(): array
+    {
+        $message = $this->createMock(AMQPMessage::class);
 
-    private AmqpEnvelope $envelope;
+        return [$message, new AmqpEnvelope($message)];
+    }
 
     public function testGetAMQPMessage(): void
     {
-        self::assertSame($this->message, $this->envelope->getAMQPMessage());
+        $message  = $this->createStub(AMQPMessage::class);
+        $envelope = new AmqpEnvelope($message);
+
+        self::assertSame($message, $envelope->getAMQPMessage());
     }
 
     public function testGetAttributes(): void
     {
-        $this->message->expects(self::once())
+        [$message, $envelope] = $this->createMockEnvelope();
+
+        $message->expects(self::once())
             ->method('get_properties')
             ->willReturn(['test' => 'abc']);
 
-        self::assertSame(['test' => 'abc'], $this->envelope->getAttributes());
+        self::assertSame(['test' => 'abc'], $envelope->getAttributes());
     }
 
     public function testAck(): void
     {
-        $this->message->expects(self::once())
+        [$message, $envelope] = $this->createMockEnvelope();
+
+        $message->expects(self::once())
             ->method('ack');
 
-        $this->envelope->ack();
+        $envelope->ack();
     }
 
     public function testNack(): void
     {
-        $this->message->expects(self::once())
+        [$message, $envelope] = $this->createMockEnvelope();
+
+        $message->expects(self::once())
             ->method('nack');
 
-        $this->envelope->nack();
+        $envelope->nack();
     }
 
     public function testGetBody(): void
     {
-        $this->message->expects(self::once())
+        [$message, $envelope] = $this->createMockEnvelope();
+
+        $message->expects(self::once())
             ->method('getBody')
             ->willReturn('test body');
 
-        self::assertSame('test body', $this->envelope->getBody());
+        self::assertSame('test body', $envelope->getBody());
     }
 
     public function testGetRoutingKey(): void
     {
-        $this->message->expects(self::once())
+        [$message, $envelope] = $this->createMockEnvelope();
+
+        $message->expects(self::once())
             ->method('getRoutingKey')
             ->willReturn('test routing key');
 
-        self::assertSame('test routing key', $this->envelope->getRoutingKey());
+        self::assertSame('test routing key', $envelope->getRoutingKey());
     }
 
     public function testGetContentType(): void
     {
-        $this->message->expects(self::once())
+        [$message, $envelope] = $this->createMockEnvelope();
+
+        $message->expects(self::once())
             ->method('get')
             ->with('content_type')
             ->willReturn('test content type');
 
-        self::assertSame('test content type', $this->envelope->getContentType());
+        self::assertSame('test content type', $envelope->getContentType());
     }
 
     public function testGetContentEncoding(): void
     {
-        $this->message->expects(self::once())
+        [$message, $envelope] = $this->createMockEnvelope();
+
+        $message->expects(self::once())
             ->method('getContentEncoding')
             ->willReturn('test content encoding');
 
-        self::assertSame('test content encoding', $this->envelope->getContentEncoding());
+        self::assertSame('test content encoding', $envelope->getContentEncoding());
     }
 
     public function testGetHeaders(): void
     {
+        [$message, $envelope] = $this->createMockEnvelope();
+
         $headers = new AMQPTable(['test' => 1]);
 
-        $this->message->expects(self::once())
+        $message->expects(self::once())
             ->method('get')
             ->with('application_headers')
             ->willReturn($headers);
 
-        self::assertSame(['test' => 1], $this->envelope->getHeaders());
+        self::assertSame(['test' => 1], $envelope->getHeaders());
     }
 
     public function testGetHeadersEmpty(): void
     {
-        $this->message->expects(self::once())
+        [$message, $envelope] = $this->createMockEnvelope();
+
+        $message->expects(self::once())
             ->method('get')
             ->with('application_headers')
             ->willReturn(null);
 
-        self::assertSame([], $this->envelope->getHeaders());
+        self::assertSame([], $envelope->getHeaders());
     }
 
     public function testGetDeliveryMode(): void
     {
-        $this->message->expects(self::once())
+        [$message, $envelope] = $this->createMockEnvelope();
+
+        $message->expects(self::once())
             ->method('get')
             ->with('delivery_mode')
             ->willReturn(AMQPMessage::DELIVERY_MODE_PERSISTENT);
 
-        self::assertSame(AMQPMessage::DELIVERY_MODE_PERSISTENT, $this->envelope->getDeliveryMode());
+        self::assertSame(AMQPMessage::DELIVERY_MODE_PERSISTENT, $envelope->getDeliveryMode());
     }
 
     public function testGetPriority(): void
     {
-        $this->message->expects(self::once())
+        [$message, $envelope] = $this->createMockEnvelope();
+
+        $message->expects(self::once())
             ->method('get')
             ->with('priority')
             ->willReturn(1);
 
-        self::assertSame(1, $this->envelope->getPriority());
+        self::assertSame(1, $envelope->getPriority());
     }
 
     public function testGetCorrelationId(): void
     {
-        $this->message->expects(self::once())
+        [$message, $envelope] = $this->createMockEnvelope();
+
+        $message->expects(self::once())
             ->method('get')
             ->with('correlation_id')
             ->willReturn('123');
 
-        self::assertSame('123', $this->envelope->getCorrelationId());
+        self::assertSame('123', $envelope->getCorrelationId());
     }
 
     public function testGetReplyTo(): void
     {
-        $this->message->expects(self::once())
+        [$message, $envelope] = $this->createMockEnvelope();
+
+        $message->expects(self::once())
             ->method('get')
             ->with('reply_to')
             ->willReturn('test reply to');
 
-        self::assertSame('test reply to', $this->envelope->getReplyTo());
+        self::assertSame('test reply to', $envelope->getReplyTo());
     }
 
     public function testGetExpiration(): void
     {
-        $this->message->expects(self::once())
+        [$message, $envelope] = $this->createMockEnvelope();
+
+        $message->expects(self::once())
             ->method('get')
             ->with('expiration')
             ->willReturn(123);
 
-        self::assertSame(123, $this->envelope->getExpiration());
+        self::assertSame(123, $envelope->getExpiration());
     }
 
     public function testGetMessageId(): void
     {
-        $this->message->expects(self::once())
+        [$message, $envelope] = $this->createMockEnvelope();
+
+        $message->expects(self::once())
             ->method('get')
             ->with('message_id')
             ->willReturn('test message id');
 
-        self::assertSame('test message id', $this->envelope->getMessageId());
+        self::assertSame('test message id', $envelope->getMessageId());
     }
 
     public function testGetTimestamp(): void
     {
-        $this->message->expects(self::once())
+        [$message, $envelope] = $this->createMockEnvelope();
+
+        $message->expects(self::once())
             ->method('get')
             ->with('timestamp')
             ->willReturn(123);
 
-        self::assertSame(123, $this->envelope->getTimestamp());
+        self::assertSame(123, $envelope->getTimestamp());
     }
 
     public function getType(): void
     {
-        $this->message->expects(self::once())
+        [$message, $envelope] = $this->createMockEnvelope();
+
+        $message->expects(self::once())
             ->method('get')
             ->with('type')
             ->willReturn('test type');
 
-        self::assertSame('test type', $this->envelope->getType());
+        self::assertSame('test type', $envelope->getType());
     }
 
     public function testGetUserId(): void
     {
-        $this->message->expects(self::once())
+        [$message, $envelope] = $this->createMockEnvelope();
+
+        $message->expects(self::once())
             ->method('get')
             ->with('user_id')
             ->willReturn('test user id');
 
-        self::assertSame('test user id', $this->envelope->getUserId());
+        self::assertSame('test user id', $envelope->getUserId());
     }
 
     public function testGetAppId(): void
     {
-        $this->message->expects(self::once())
+        [$message, $envelope] = $this->createMockEnvelope();
+
+        $message->expects(self::once())
             ->method('get')
             ->with('app_id')
             ->willReturn('test app id');
 
-        self::assertSame('test app id', $this->envelope->getAppId());
+        self::assertSame('test app id', $envelope->getAppId());
     }
 
     public function testGetClusterId(): void
     {
-        $this->message->expects(self::once())
+        [$message, $envelope] = $this->createMockEnvelope();
+
+        $message->expects(self::once())
             ->method('get')
             ->with('cluster_id')
             ->willReturn('test cluster id');
 
-        self::assertSame('test cluster id', $this->envelope->getClusterId());
+        self::assertSame('test cluster id', $envelope->getClusterId());
     }
 
     public function testGetReturnsNullIfPropertyDoesNotExist(): void
     {
-        $this->message->expects(self::once())
+        [$message, $envelope] = $this->createMockEnvelope();
+
+        $message->expects(self::once())
             ->method('get')
             ->with('type')
             ->willReturn($this->throwException(new OutOfBoundsException()));
 
-        self::assertNull($this->envelope->getType());
+        self::assertNull($envelope->getType());
     }
 
     public function testWithRealAMQPMessage(): void
@@ -244,14 +292,5 @@ class AmqpEnvelopeTest extends TestCase
         self::assertSame('text/plain', $envelope->getContentType());
         self::assertSame(AMQPMessage::DELIVERY_MODE_PERSISTENT, $envelope->getDeliveryMode());
         self::assertSame(['foo' => 'bar'], $envelope->getHeaders());
-    }
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->message = $this->createMock(AMQPMessage::class);
-
-        $this->envelope = new AmqpEnvelope($this->message);
     }
 }

--- a/tests/Transport/AmqpReceiverTest.php
+++ b/tests/Transport/AmqpReceiverTest.php
@@ -4,17 +4,12 @@ declare(strict_types=1);
 
 namespace Jwage\PhpAmqpLibMessengerBundle\Tests\Transport;
 
-use Jwage\PhpAmqpLibMessengerBundle\RetryFactory;
 use Jwage\PhpAmqpLibMessengerBundle\Tests\TestCase;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpConnectionFactory;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpEnvelope;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpReceivedStamp;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpReceiver;
-use Jwage\PhpAmqpLibMessengerBundle\Transport\Config\ConnectionConfig;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\Connection;
 use PhpAmqpLib\Message\AMQPMessage;
-use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Log\LoggerInterface;
 use stdClass;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
@@ -24,19 +19,6 @@ use function serialize;
 
 class AmqpReceiverTest extends TestCase
 {
-    /** @var LoggerInterface&MockObject */
-    private LoggerInterface $logger;
-
-    private RetryFactory $retryFactory;
-
-    /** @var Connection&MockObject */
-    private Connection $connection;
-
-    /** @var SerializerInterface&MockObject */
-    private SerializerInterface $serializer;
-
-    private AmqpReceiver $receiver;
-
     public function testGet(): void
     {
         $message      = new stdClass();
@@ -44,20 +26,23 @@ class AmqpReceiverTest extends TestCase
         $amqpMessage  = new AMQPMessage(serialize($message), ['message_id' => '1']);
         $amqpEnvelope = new AmqpEnvelope($amqpMessage);
 
-        $this->connection->expects(self::any())
-            ->method('getQueueNames')
+        $connection = $this->createMock(Connection::class);
+        $serializer = $this->createMock(SerializerInterface::class);
+
+        $connection->method('getQueueNames')
             ->willReturn(['queue_name']);
 
-        $this->connection->expects(self::once())
+        $connection->expects(self::once())
             ->method('consume')
             ->willReturn([$amqpEnvelope]);
 
-        $this->serializer->expects(self::once())
+        $serializer->expects(self::once())
             ->method('decode')
             ->with(['body' => 'O:8:"stdClass":0:{}', 'headers' => []])
             ->willReturn($envelope);
 
-        $iterable = $this->receiver->get();
+        $receiver = new AmqpReceiver($connection, $serializer);
+        $iterable = $receiver->get();
 
         $envelopes = [];
 
@@ -92,7 +77,12 @@ class AmqpReceiverTest extends TestCase
 
         $envelope = new Envelope(new stdClass(), [$stamp]);
 
-        $this->receiver->ack($envelope);
+        $receiver = new AmqpReceiver(
+            $this->createStub(Connection::class),
+            $this->createStub(SerializerInterface::class),
+        );
+
+        $receiver->ack($envelope);
     }
 
     public function testReject(): void
@@ -106,39 +96,27 @@ class AmqpReceiverTest extends TestCase
 
         $envelope = new Envelope(new stdClass(), [$stamp]);
 
-        $this->receiver->reject($envelope);
+        $receiver = new AmqpReceiver(
+            $this->createStub(Connection::class),
+            $this->createStub(SerializerInterface::class),
+        );
+
+        $receiver->reject($envelope);
     }
 
     public function testGetMessageCount(): void
     {
-        $this->connection->expects(self::once())
+        $connection = $this->createMock(Connection::class);
+
+        $connection->expects(self::once())
             ->method('countMessagesInQueues')
             ->willReturn(10);
 
-        self::assertSame(10, $this->receiver->getMessageCount());
-    }
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->logger = $this->createMock(LoggerInterface::class);
-
-        $this->retryFactory = new RetryFactory($this->logger);
-
-        $amqpConnectionFactory = new AmqpConnectionFactory();
-        $connectionConfig      = new ConnectionConfig();
-
-        $this->connection = $this->getMockBuilder(Connection::class)
-            ->onlyMethods(['getQueueNames', 'consume', 'countMessagesInQueues'])
-            ->setConstructorArgs([$this->retryFactory, $amqpConnectionFactory, $connectionConfig])
-            ->getMock();
-
-        $this->serializer = $this->createMock(SerializerInterface::class);
-
-        $this->receiver = new AmqpReceiver(
-            $this->connection,
-            $this->serializer,
+        $receiver = new AmqpReceiver(
+            $connection,
+            $this->createStub(SerializerInterface::class),
         );
+
+        self::assertSame(10, $receiver->getMessageCount());
     }
 }

--- a/tests/Transport/AmqpTransportFactoryTest.php
+++ b/tests/Transport/AmqpTransportFactoryTest.php
@@ -8,19 +8,17 @@ use Jwage\PhpAmqpLibMessengerBundle\Tests\TestCase;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpTransport;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpTransportFactory;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\ConnectionFactory;
-use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 class AmqpTransportFactoryTest extends TestCase
 {
-    /** @var ConnectionFactory&MockObject */
     private ConnectionFactory $connectionFactory;
 
     private AmqpTransportFactory $factory;
 
     public function testCreateTransport(): void
     {
-        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer = $this->createStub(SerializerInterface::class);
 
         $transport = $this->factory->createTransport('phpamqplib://localhost', [], $serializer);
 
@@ -38,7 +36,7 @@ class AmqpTransportFactoryTest extends TestCase
     {
         parent::setUp();
 
-        $this->connectionFactory = $this->createMock(ConnectionFactory::class);
+        $this->connectionFactory = $this->createStub(ConnectionFactory::class);
 
         $this->factory = new AmqpTransportFactory($this->connectionFactory);
     }

--- a/tests/Transport/AmqpTransportTest.php
+++ b/tests/Transport/AmqpTransportTest.php
@@ -9,30 +9,32 @@ use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpReceiver;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpSender;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpTransport;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\Connection;
-use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 class AmqpTransportTest extends TestCase
 {
-    /** @var Connection&MockObject */
-    private Connection $connection;
-
-    /** @var AMQPReceiver&MockObject */
-    private AmqpReceiver $receiver;
-
-    /** @var AMQPSender&MockObject */
-    private AmqpSender $sender;
-
-    /** @var SerializerInterface&MockObject */
-    private SerializerInterface $serializer;
-
-    private AmqpTransport $transport;
+    private function createTransport(
+        Connection|null $connection = null,
+        AmqpReceiver|null $receiver = null,
+        AmqpSender|null $sender = null,
+        SerializerInterface|null $serializer = null,
+    ): AmqpTransport {
+        return new AmqpTransport(
+            connection: $connection ?? $this->createStub(Connection::class),
+            receiver: $receiver ?? $this->createStub(AmqpReceiver::class),
+            sender: $sender ?? $this->createStub(AmqpSender::class),
+            serializer: $serializer ?? $this->createStub(SerializerInterface::class),
+        );
+    }
 
     public function testGetConnection(): void
     {
-        self::assertSame($this->connection, $this->transport->getConnection());
+        $connection = $this->createStub(Connection::class);
+        $transport  = $this->createTransport(connection: $connection);
+
+        self::assertSame($connection, $transport->getConnection());
     }
 
     public function testGet(): void
@@ -42,81 +44,79 @@ class AmqpTransportTest extends TestCase
 
         $return = [$envelope1, $envelope2];
 
-        $this->receiver->expects(self::once())
+        $receiver  = $this->createMock(AmqpReceiver::class);
+        $transport = $this->createTransport(receiver: $receiver);
+
+        $receiver->expects(self::once())
             ->method('get')
             ->willReturn($return);
 
-        self::assertSame($return, $this->transport->get());
+        self::assertSame($return, $transport->get());
     }
 
     public function testAck(): void
     {
         $envelope = new Envelope(new stdClass());
 
-        $this->receiver->expects(self::once())
+        $receiver  = $this->createMock(AmqpReceiver::class);
+        $transport = $this->createTransport(receiver: $receiver);
+
+        $receiver->expects(self::once())
             ->method('ack')
             ->with($envelope);
 
-        $this->transport->ack($envelope);
+        $transport->ack($envelope);
     }
 
     public function testReject(): void
     {
         $envelope = new Envelope(new stdClass());
 
-        $this->receiver->expects(self::once())
+        $receiver  = $this->createMock(AmqpReceiver::class);
+        $transport = $this->createTransport(receiver: $receiver);
+
+        $receiver->expects(self::once())
             ->method('reject')
             ->with($envelope);
 
-        $this->transport->reject($envelope);
+        $transport->reject($envelope);
     }
 
     public function testSend(): void
     {
         $envelope = new Envelope(new stdClass());
 
-        $this->sender->expects(self::once())
+        $sender    = $this->createMock(AmqpSender::class);
+        $transport = $this->createTransport(sender: $sender);
+
+        $sender->expects(self::once())
             ->method('send')
             ->with($envelope)
             ->willReturn($envelope);
 
-        self::assertSame($envelope, $this->transport->send($envelope));
+        self::assertSame($envelope, $transport->send($envelope));
     }
 
     public function testGetMessageCount(): void
     {
-        $this->receiver->expects(self::once())
+        $receiver  = $this->createMock(AmqpReceiver::class);
+        $transport = $this->createTransport(receiver: $receiver);
+
+        $receiver->expects(self::once())
             ->method('getMessageCount')
             ->willReturn(1);
 
-        self::assertSame(1, $this->transport->getMessageCount());
+        self::assertSame(1, $transport->getMessageCount());
     }
 
     public function testSetup(): void
     {
-        $this->connection->expects(self::once())
+        $connection = $this->createMock(Connection::class);
+        $transport  = $this->createTransport(connection: $connection);
+
+        $connection->expects(self::once())
             ->method('setup');
 
-        $this->transport->setup();
-    }
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->connection = $this->createMock(Connection::class);
-
-        $this->receiver = $this->createMock(AmqpReceiver::class);
-
-        $this->sender = $this->createMock(AmqpSender::class);
-
-        $this->serializer = $this->createMock(SerializerInterface::class);
-
-        $this->transport = new AmqpTransport(
-            connection: $this->connection,
-            receiver: $this->receiver,
-            sender: $this->sender,
-            serializer: $this->serializer,
-        );
+        $transport->setup();
     }
 }

--- a/tests/Transport/ConnectionTest.php
+++ b/tests/Transport/ConnectionTest.php
@@ -30,40 +30,147 @@ class ConnectionTest extends TestCase
 {
     private RetryFactory $retryFactory;
 
-    /** @var AMQPConnectionFactory&MockObject */
-    private AmqpConnectionFactory $amqpConnectionFactory;
-
-    /** @var AMQPStreamConnection&MockObject */
-    private AMQPStreamConnection $amqpConnection;
-
-    /** @var AMQPChannel&MockObject */
-    private AMQPChannel $amqpChannel;
-
     private Connection $connection;
+
+    /**
+     * Creates a Connection with all stubs (no mock expectations possible).
+     * Used for tests that don't need to verify interactions.
+     */
+    private function createConnectionWithStubs(ConnectionConfig|null $connectionConfig = null): Connection
+    {
+        $factory        = $this->createStub(AmqpConnectionFactory::class);
+        $amqpConnection = $this->createStub(AMQPStreamConnection::class);
+        $amqpChannel    = $this->createStub(AMQPChannel::class);
+
+        $factory->method('create')->willReturn($amqpConnection);
+        $amqpConnection->method('channel')->willReturn($amqpChannel);
+
+        return new Connection(
+            retryFactory: $this->retryFactory,
+            amqpConnectionFactory: $factory,
+            connectionConfig: $connectionConfig ?? $this->getDefaultConfig(),
+        );
+    }
+
+    /**
+     * Creates a Connection with a mock AMQPChannel for verifying channel interactions.
+     *
+     * @return array{Connection, AMQPChannel&MockObject}
+     */
+    private function createConnectionWithChannelMock(ConnectionConfig|null $connectionConfig = null): array
+    {
+        $factory        = $this->createStub(AmqpConnectionFactory::class);
+        $amqpConnection = $this->createStub(AMQPStreamConnection::class);
+        $amqpChannel    = $this->createMock(AMQPChannel::class);
+
+        $factory->method('create')->willReturn($amqpConnection);
+        $amqpConnection->method('channel')->willReturn($amqpChannel);
+        $amqpChannel->method('confirm_select');
+
+        $connection = new Connection(
+            retryFactory: $this->retryFactory,
+            amqpConnectionFactory: $factory,
+            connectionConfig: $connectionConfig ?? $this->getDefaultConfig(),
+        );
+
+        return [$connection, $amqpChannel];
+    }
+
+    /**
+     * Creates a Connection with a mock AMQPStreamConnection for verifying connection interactions.
+     *
+     * @return array{Connection, AMQPStreamConnection&MockObject}
+     */
+    private function createConnectionWithConnectionMock(ConnectionConfig|null $connectionConfig = null): array
+    {
+        $factory        = $this->createStub(AmqpConnectionFactory::class);
+        $amqpConnection = $this->createMock(AMQPStreamConnection::class);
+        $amqpChannel    = $this->createStub(AMQPChannel::class);
+
+        $factory->method('create')->willReturn($amqpConnection);
+        $amqpConnection->method('channel')->willReturn($amqpChannel);
+
+        $connection = new Connection(
+            retryFactory: $this->retryFactory,
+            amqpConnectionFactory: $factory,
+            connectionConfig: $connectionConfig ?? $this->getDefaultConfig(),
+        );
+
+        return [$connection, $amqpConnection];
+    }
+
+    /**
+     * Creates a Connection with mock AMQPStreamConnection and AMQPChannel.
+     * Does not pre-configure channel() or confirm_select() — tests must configure these.
+     *
+     * @return array{Connection, AMQPStreamConnection&MockObject, AMQPChannel&MockObject}
+     */
+    private function createConnectionWithAllMocks(ConnectionConfig|null $connectionConfig = null): array
+    {
+        $factory        = $this->createStub(AmqpConnectionFactory::class);
+        $amqpConnection = $this->createMock(AMQPStreamConnection::class);
+        $amqpChannel    = $this->createMock(AMQPChannel::class);
+
+        $factory->method('create')->willReturn($amqpConnection);
+
+        $connection = new Connection(
+            retryFactory: $this->retryFactory,
+            amqpConnectionFactory: $factory,
+            connectionConfig: $connectionConfig ?? $this->getDefaultConfig(),
+        );
+
+        return [$connection, $amqpConnection, $amqpChannel];
+    }
+
+    private function getDefaultConfig(): ConnectionConfig
+    {
+        return new ConnectionConfig(
+            confirmEnabled: true,
+            confirmTimeout: 5.0,
+            exchange: new ExchangeConfig(name: 'exchange_name'),
+            queues: [
+                'queue_name' => new QueueConfig(
+                    name: 'queue_name',
+                    bindings: [
+                        'routing_key' => new BindingConfig(
+                            routingKey: 'routing_key',
+                            arguments: ['arg1' => 'value1', 'arg2' => 'value2'],
+                        ),
+                    ],
+                ),
+            ],
+        );
+    }
 
     public function testClose(): void
     {
-        $this->amqpConnection->expects(self::once())
+        [$connection, $amqpConnection] = $this->createConnectionWithConnectionMock();
+
+        $amqpConnection->expects(self::once())
             ->method('close');
 
-        $this->connection->channel();
+        $connection->channel();
 
-        $this->connection->close();
+        $connection->close();
     }
 
     public function testReconnect(): void
     {
-        $this->connection->channel();
+        [$connection, $amqpConnection] = $this->createConnectionWithConnectionMock();
 
-        $this->amqpConnection->expects(self::once())
+        $connection->channel();
+
+        $amqpConnection->expects(self::once())
             ->method('reconnect');
 
-        $this->connection->reconnect();
+        $connection->reconnect();
     }
 
     public function testSetup(): void
     {
-        $this->amqpChannel->expects(self::exactly(2))
+        [$connection, $amqpChannel] = $this->createConnectionWithChannelMock();
+
+        $amqpChannel->expects(self::exactly(2))
             ->method('exchange_declare')
             ->with(...self::withConsecutive(
                 [
@@ -88,7 +195,7 @@ class ConnectionTest extends TestCase
                 ],
             ));
 
-        $this->amqpChannel->expects(self::once())
+        $amqpChannel->expects(self::once())
             ->method('queue_declare')
             ->with(
                 queue: 'queue_name',
@@ -100,7 +207,7 @@ class ConnectionTest extends TestCase
                 arguments: new AMQPTable([]),
             );
 
-        $this->amqpChannel->expects(self::once())
+        $amqpChannel->expects(self::once())
             ->method('queue_bind')
             ->with(
                 queue: 'queue_name',
@@ -110,12 +217,12 @@ class ConnectionTest extends TestCase
                 arguments: new AMQPTable(['arg1' => 'value1', 'arg2' => 'value2']),
             );
 
-        $this->connection->setup();
+        $connection->setup();
     }
 
     public function testSetupWithAutoSetupDisabled(): void
     {
-        $connection = $this->getTestConnection(new ConnectionConfig(
+        [$connection, $amqpChannel] = $this->createConnectionWithChannelMock(new ConnectionConfig(
             autoSetup: false,
             exchange: new ExchangeConfig(name: 'exchange_name'),
             queues: [
@@ -131,7 +238,7 @@ class ConnectionTest extends TestCase
             ],
         ));
 
-        $this->amqpChannel->expects(self::exactly(2))
+        $amqpChannel->expects(self::exactly(2))
             ->method('exchange_declare')
             ->with(...self::withConsecutive(
                 [
@@ -156,7 +263,7 @@ class ConnectionTest extends TestCase
                 ],
             ));
 
-        $this->amqpChannel->expects(self::once())
+        $amqpChannel->expects(self::once())
             ->method('queue_declare')
             ->with(
                 queue: 'queue_name',
@@ -168,7 +275,7 @@ class ConnectionTest extends TestCase
                 arguments: new AMQPTable([]),
             );
 
-        $this->amqpChannel->expects(self::once())
+        $amqpChannel->expects(self::once())
             ->method('queue_bind')
             ->with(
                 queue: 'queue_name',
@@ -183,12 +290,12 @@ class ConnectionTest extends TestCase
 
     public function testSetupWithDelayDisabled(): void
     {
-        $connection = $this->getTestConnection(new ConnectionConfig(
+        [$connection, $amqpChannel] = $this->createConnectionWithChannelMock(new ConnectionConfig(
             exchange: new ExchangeConfig(name: 'exchange_name'),
             delay: new DelayConfig(enabled: false),
         ));
 
-        $this->amqpChannel->expects(self::once())
+        $amqpChannel->expects(self::once())
             ->method('exchange_declare')
             ->with(...self::withConsecutive(
                 [
@@ -208,30 +315,34 @@ class ConnectionTest extends TestCase
 
     public function testChannel(): void
     {
-        $this->amqpConnection->expects(self::once())
-            ->method('channel')
-            ->willReturn($this->amqpChannel);
+        [$connection, $amqpConnection, $amqpChannel] = $this->createConnectionWithAllMocks();
 
-        $this->amqpChannel->expects(self::once())
+        $amqpConnection->expects(self::once())
+            ->method('channel')
+            ->willReturn($amqpChannel);
+
+        $amqpChannel->expects(self::once())
             ->method('confirm_select');
 
-        self::assertSame($this->amqpChannel, $this->connection->channel());
-        self::assertSame($this->amqpChannel, $this->connection->channel());
+        self::assertSame($amqpChannel, $connection->channel());
+        self::assertSame($amqpChannel, $connection->channel());
     }
 
     public function testChannelWithConfirmDisabled(): void
     {
-        $this->amqpConnection->expects(self::once())
-            ->method('channel')
-            ->willReturn($this->amqpChannel);
+        [$connection, $amqpConnection, $amqpChannel] = $this->createConnectionWithAllMocks(
+            new ConnectionConfig(confirmEnabled: false),
+        );
 
-        $this->amqpChannel->expects(self::never())
+        $amqpConnection->expects(self::once())
+            ->method('channel')
+            ->willReturn($amqpChannel);
+
+        $amqpChannel->expects(self::never())
             ->method('confirm_select');
 
-        $connection = $this->getTestConnection(new ConnectionConfig(confirmEnabled: false));
-
-        self::assertSame($this->amqpChannel, $connection->channel());
-        self::assertSame($this->amqpChannel, $connection->channel());
+        self::assertSame($amqpChannel, $connection->channel());
+        self::assertSame($amqpChannel, $connection->channel());
     }
 
     public function testGet(): void
@@ -244,6 +355,8 @@ class ConnectionTest extends TestCase
 
     public function testPublish(): void
     {
+        [$connection, $amqpChannel] = $this->createConnectionWithChannelMock();
+
         $body    = 'test body';
         $headers = ['header1' => 'value1', 'header2' => 'value2'];
 
@@ -256,7 +369,7 @@ class ConnectionTest extends TestCase
             ],
         );
 
-        $this->amqpChannel->expects(self::once())
+        $amqpChannel->expects(self::once())
             ->method('basic_publish')
             ->with(
                 body: $amqpMessage,
@@ -264,15 +377,20 @@ class ConnectionTest extends TestCase
                 routing_key: '',
             );
 
-        $this->amqpChannel->expects(self::once())
+        $amqpChannel->expects(self::once())
             ->method('wait_for_pending_acks')
             ->with(timeout: 5);
 
-        $this->connection->publish(body: 'test body', headers: $headers);
+        $connection->publish(body: 'test body', headers: $headers);
     }
 
     public function testPublishWithConfirmDisabled(): void
     {
+        [$connection, $amqpChannel] = $this->createConnectionWithChannelMock(new ConnectionConfig(
+            exchange: new ExchangeConfig(name: 'exchange_name'),
+            confirmEnabled: false,
+        ));
+
         $body = 'test body';
 
         $amqpMessage = new AMQPMessage(
@@ -284,7 +402,7 @@ class ConnectionTest extends TestCase
             ],
         );
 
-        $this->amqpChannel->expects(self::once())
+        $amqpChannel->expects(self::once())
             ->method('basic_publish')
             ->with(
                 body: $amqpMessage,
@@ -292,19 +410,16 @@ class ConnectionTest extends TestCase
                 routing_key: '',
             );
 
-        $this->amqpChannel->expects(self::never())
+        $amqpChannel->expects(self::never())
             ->method('wait_for_pending_acks');
-
-        $connection = $this->getTestConnection(new ConnectionConfig(
-            exchange: new ExchangeConfig(name: 'exchange_name'),
-            confirmEnabled: false,
-        ));
 
         $connection->publish(body: 'test body');
     }
 
     public function testPublishWithBatchSizeGreaterThanOne(): void
     {
+        [$connection, $amqpChannel] = $this->createConnectionWithChannelMock();
+
         $body1 = 'test body 1';
         $body2 = 'test body 2';
 
@@ -326,26 +441,28 @@ class ConnectionTest extends TestCase
             ],
         );
 
-        $this->amqpChannel->expects(self::exactly(2))
+        $amqpChannel->expects(self::exactly(2))
             ->method('batch_basic_publish')
             ->with(...self::withConsecutive(
                 [$amqpMessage1, 'exchange_name'],
                 [$amqpMessage2, 'exchange_name'],
             ));
 
-        $this->amqpChannel->expects(self::once())
+        $amqpChannel->expects(self::once())
             ->method('publish_batch');
 
-        $this->amqpChannel->expects(self::once())
+        $amqpChannel->expects(self::once())
             ->method('wait_for_pending_acks')
             ->with(timeout: 5);
 
-        $this->connection->publish(body: $body1, batchSize: 2);
-        $this->connection->publish(body: $body2, batchSize: 2);
+        $connection->publish(body: $body1, batchSize: 2);
+        $connection->publish(body: $body2, batchSize: 2);
     }
 
     public function testPublishWithBatchSizeGreaterThanOneAndRetryAttemptDoesNotBatchPublish(): void
     {
+        [$connection, $amqpChannel] = $this->createConnectionWithChannelMock();
+
         $body = 'test body';
 
         $amqpMessage = new AMQPMessage(
@@ -364,36 +481,40 @@ class ConnectionTest extends TestCase
             retryRoutingKey: 'test_retry_routing_key',
         );
 
-        $this->amqpChannel->expects(self::once())
+        $amqpChannel->expects(self::once())
             ->method('basic_publish');
 
-        $this->amqpChannel->expects(self::once())
+        $amqpChannel->expects(self::once())
             ->method('wait_for_pending_acks')
             ->with(timeout: 5);
 
-        $this->connection->publish(body: $body, batchSize: 2, amqpStamp: $amqpStamp);
+        $connection->publish(body: $body, batchSize: 2, amqpStamp: $amqpStamp);
     }
 
     public function testFlush(): void
     {
-        $this->amqpChannel->expects(self::once())
+        [$connection, $amqpChannel] = $this->createConnectionWithChannelMock();
+
+        $amqpChannel->expects(self::once())
             ->method('publish_batch');
 
-        $this->amqpChannel->expects(self::once())
+        $amqpChannel->expects(self::once())
             ->method('wait_for_pending_acks')
             ->with(timeout: 5);
 
-        $this->connection->flush();
+        $connection->flush();
     }
 
     public function testFlushWithConfirmDisabled(): void
     {
-        $connection = $this->getTestConnection(new ConnectionConfig(confirmEnabled: false));
+        [$connection, $amqpChannel] = $this->createConnectionWithChannelMock(
+            new ConnectionConfig(confirmEnabled: false),
+        );
 
-        $this->amqpChannel->expects(self::once())
+        $amqpChannel->expects(self::once())
             ->method('publish_batch');
 
-        $this->amqpChannel->expects(self::never())
+        $amqpChannel->expects(self::never())
             ->method('wait_for_pending_acks');
 
         $connection->flush();
@@ -401,11 +522,13 @@ class ConnectionTest extends TestCase
 
     public function testCountMessagesInQueues(): void
     {
-        $this->amqpChannel->expects(self::once())
+        [$connection, $amqpChannel] = $this->createConnectionWithChannelMock();
+
+        $amqpChannel->expects(self::once())
             ->method('queue_declare')
             ->willReturn(['queue_name', 2]);
 
-        self::assertSame(2, $this->connection->countMessagesInQueues());
+        self::assertSame(2, $connection->countMessagesInQueues());
     }
 
     public function testGetQueueNames(): void
@@ -475,47 +598,6 @@ class ConnectionTest extends TestCase
 
         $this->retryFactory = new RetryFactory();
 
-        $this->amqpConnectionFactory = $this->createMock(AmqpConnectionFactory::class);
-
-        $this->amqpConnection = $this->createMock(AMQPStreamConnection::class);
-
-        $this->amqpChannel = $this->createMock(AMQPChannel::class);
-
-        $this->amqpConnectionFactory->expects(self::any())
-            ->method('create')
-            ->willReturn($this->amqpConnection);
-
-        $this->amqpConnection->expects(self::any())
-            ->method('channel')
-            ->willReturn($this->amqpChannel);
-
-        $this->amqpChannel->expects(self::any())
-            ->method('confirm_select');
-
-        $this->connection = $this->getTestConnection();
-    }
-
-    private function getTestConnection(ConnectionConfig|null $connectionConfig = null): Connection
-    {
-        return new Connection(
-            retryFactory: $this->retryFactory,
-            amqpConnectionFactory: $this->amqpConnectionFactory,
-            connectionConfig: $connectionConfig ?? new ConnectionConfig(
-                confirmEnabled: true,
-                confirmTimeout: 5.0,
-                exchange: new ExchangeConfig(name: 'exchange_name'),
-                queues: [
-                    'queue_name' => new QueueConfig(
-                        name: 'queue_name',
-                        bindings: [
-                            'routing_key' => new BindingConfig(
-                                routingKey: 'routing_key',
-                                arguments: ['arg1' => 'value1', 'arg2' => 'value2'],
-                            ),
-                        ],
-                    ),
-                ],
-            ),
-        );
+        $this->connection = $this->createConnectionWithStubs();
     }
 }


### PR DESCRIPTION
Well this is more like refactoring, but sooner or later it will be required if you want to support PHPUnit 13.

You may run the tests with `SYMFONY_DEPRECATIONS_HELPER='max[indirect]=0&verbose=1'` if you have to resolve symfony internal (indirect) deprecation notices.