### PR TITLE
Make retry/delay queue durable for RabbitMQ 4.3 compatibility

### DIFF
--- a/src/Transport/Connection.php
+++ b/src/Transport/Connection.php
@@ -445,8 +445,13 @@ class Connection
             $delayQueueName = $this->connectionConfig
                 ->getDelayQueueName($delay, $routingKey, $isRetryAttempt);
 
+            // Declare the delay queue as durable. The queue is still auto-cleaned via the
+            // x-expires argument; durability is required because RabbitMQ 4.3+ deprecates the
+            // `transient_nonexcl_queues` feature (durable=false + exclusive=false), and avoids
+            // losing in-flight retry messages across broker restarts.
             $this->channel()->queue_declare(
                 queue: $delayQueueName,
+                durable: true,
                 nowait: false,
                 arguments: new AMQPTable([
                     'x-message-ttl' => $delay,

--- a/tests/Transport/ConnectionTest.php
+++ b/tests/Transport/ConnectionTest.php
@@ -384,6 +384,43 @@ class ConnectionTest extends TestCase
         $connection->publish(body: 'test body', headers: $headers);
     }
 
+    public function testPublishWithDelayDeclaresDurableDelayQueue(): void
+    {
+        // RabbitMQ 4.3+ deprecates the `transient_nonexcl_queues` feature
+        // (durable=false + exclusive=false). The delay queue must therefore
+        // be declared as durable.
+        [$connection, $amqpChannel] = $this->createConnectionWithChannelMock(new ConnectionConfig(
+            autoSetup: false,
+            exchange: new ExchangeConfig(name: 'exchange_name'),
+        ));
+
+        $amqpChannel->expects(self::once())
+            ->method('exchange_declare');
+
+        $declaredArgs = [];
+        $amqpChannel->expects(self::once())
+            ->method('queue_declare')
+            ->willReturnCallback(static function (...$args) use (&$declaredArgs): array {
+                $declaredArgs = $args;
+
+                return [$args[0] ?? '', 0];
+            });
+
+        $amqpChannel->expects(self::once())
+            ->method('queue_bind');
+
+        $amqpChannel->expects(self::once())
+            ->method('basic_publish');
+
+        $amqpChannel->expects(self::once())
+            ->method('wait_for_pending_acks');
+
+        $connection->publish(body: 'test body', delayInMs: 5000);
+
+        // queue_declare positional signature: (queue, passive, durable, exclusive, auto_delete, nowait, arguments, ticket)
+        self::assertTrue($declaredArgs[2] ?? false, 'Delay queue must be declared with durable=true');
+    }
+
     public function testPublishWithConfirmDisabled(): void
     {
         [$connection, $amqpChannel] = $this->createConnectionWithChannelMock(new ConnectionConfig(


### PR DESCRIPTION
RabbitMQ 4.3 changes the default of the `transient_nonexcl_queues` deprecated feature flag from `permitted_by_default` to `denied_by_default`. This flag covers queues declared with both `durable=false` and `exclusive=false`.

`Connection::setupDelayQueue()` calls `queue_declare()` passing only `queue`, `nowait` and `arguments`. The boolean flags therefore use php-amqplib's defaults (`durable=false`, `exclusive=false`, `auto_delete=true`), which matches the deprecated case. On RabbitMQ 4.3, the declaration fails with:

    INTERNAL_ERROR - Feature `transient_nonexcl_queues` is deprecated.

Setting `durable=true` fixes it. The queue is still auto-cleaned via the existing `x-expires` argument, and making it durable is arguably better anyway: retry messages currently in flight survive a broker restart during the delay, whereas before the queue and its messages would be lost.

Also adds a unit test that the delay queue is declared with `durable=true`.