### PR TITLE
Retry delay queue setup on stale AMQP connections during publish.

### DIFF
--- a/src/PhpAmqpLibMessengerBundle.php
+++ b/src/PhpAmqpLibMessengerBundle.php
@@ -9,9 +9,7 @@ use Override;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-/**
- * @psalm-suppress DeprecatedInterface
- */
+/** @psalm-suppress DeprecatedInterface */
 class PhpAmqpLibMessengerBundle extends Bundle
 {
     #[Override]

--- a/src/PhpAmqpLibMessengerBundle.php
+++ b/src/PhpAmqpLibMessengerBundle.php
@@ -9,6 +9,9 @@ use Override;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
+/**
+ * @psalm-suppress DeprecatedInterface
+ */
 class PhpAmqpLibMessengerBundle extends Bundle
 {
     #[Override]

--- a/src/Transport/Connection.php
+++ b/src/Transport/Connection.php
@@ -428,7 +428,10 @@ class Connection
         })->run();
     }
 
-    /** @throws AMQPExceptionInterface */
+    /**
+     * @throws AMQPExceptionInterface
+     * @throws TransportException
+     */
     private function setupDelayExchange(): void
     {
         $this->channel()->exchange_declare(
@@ -444,7 +447,10 @@ class Connection
         $this->autoSetupDelay = false;
     }
 
-    /** @throws AMQPExceptionInterface */
+    /**
+     * @throws AMQPExceptionInterface
+     * @throws TransportException
+     */
     private function setupDelayQueue(int $delay, string|null $routingKey, bool $isRetryAttempt): void
     {
         $delayQueueName = $this->connectionConfig

--- a/src/Transport/Connection.php
+++ b/src/Transport/Connection.php
@@ -94,13 +94,21 @@ class Connection
         $this->setupExchangeAndQueues();
 
         if ($this->connectionConfig->delay->enabled) {
-            $this->setupDelayExchange();
+            try {
+                $this->setupDelayExchange();
+            } catch (AMQPExceptionInterface $e) {
+                throw new TransportException($e->getMessage(), 0, $e);
+            }
         }
     }
 
     /** @throws TransportException */
     public function channel(): AMQPChannel
     {
+        if ($this->channel !== null && ! $this->isConnected()) {
+            $this->channel = null;
+        }
+
         if ($this->channel === null) {
             $channel = $this->retryWithReconnect(function (): AMQPChannel {
                 $channel = $this->connection()->channel();
@@ -411,60 +419,54 @@ class Connection
         string|null $routingKey,
         bool $isRetryAttempt,
     ): void {
-        if ($this->autoSetupDelay) {
-            $this->setupDelayExchange();
-        }
+        $this->retryWithReconnect(function () use ($delay, $routingKey, $isRetryAttempt): void {
+            if ($this->autoSetupDelay) {
+                $this->setupDelayExchange();
+            }
 
-        $this->setupDelayQueue($delay, $routingKey, $isRetryAttempt);
+            $this->setupDelayQueue($delay, $routingKey, $isRetryAttempt);
+        })->run();
     }
 
-    /** @throws TransportException */
+    /** @throws AMQPExceptionInterface */
     private function setupDelayExchange(): void
     {
-        try {
-            $this->channel()->exchange_declare(
-                exchange: $this->connectionConfig->delay->exchange->name,
-                type: $this->connectionConfig->delay->exchange->type,
-                passive: $this->connectionConfig->delay->exchange->passive,
-                durable: $this->connectionConfig->delay->exchange->durable,
-                auto_delete: $this->connectionConfig->delay->exchange->autoDelete,
-                nowait: false,
-                arguments: new AMQPTable($this->connectionConfig->delay->exchange->arguments),
-            );
+        $this->channel()->exchange_declare(
+            exchange: $this->connectionConfig->delay->exchange->name,
+            type: $this->connectionConfig->delay->exchange->type,
+            passive: $this->connectionConfig->delay->exchange->passive,
+            durable: $this->connectionConfig->delay->exchange->durable,
+            auto_delete: $this->connectionConfig->delay->exchange->autoDelete,
+            nowait: false,
+            arguments: new AMQPTable($this->connectionConfig->delay->exchange->arguments),
+        );
 
-            $this->autoSetupDelay = false;
-        } catch (AMQPExceptionInterface $e) {
-            throw new TransportException($e->getMessage(), 0, $e);
-        }
+        $this->autoSetupDelay = false;
     }
 
-    /** @throws TransportException */
+    /** @throws AMQPExceptionInterface */
     private function setupDelayQueue(int $delay, string|null $routingKey, bool $isRetryAttempt): void
     {
-        try {
-            $delayQueueName = $this->connectionConfig
-                ->getDelayQueueName($delay, $routingKey, $isRetryAttempt);
+        $delayQueueName = $this->connectionConfig
+            ->getDelayQueueName($delay, $routingKey, $isRetryAttempt);
 
-            $this->channel()->queue_declare(
-                queue: $delayQueueName,
-                nowait: false,
-                arguments: new AMQPTable([
-                    'x-message-ttl' => $delay,
-                    'x-expires' => $delay + 10000,
-                    'x-dead-letter-exchange' => $isRetryAttempt ? '' : $this->connectionConfig->exchange->name,
-                    'x-dead-letter-routing-key' => $routingKey ?? '',
-                ]),
-            );
+        $this->channel()->queue_declare(
+            queue: $delayQueueName,
+            nowait: false,
+            arguments: new AMQPTable([
+                'x-message-ttl' => $delay,
+                'x-expires' => $delay + 10000,
+                'x-dead-letter-exchange' => $isRetryAttempt ? '' : $this->connectionConfig->exchange->name,
+                'x-dead-letter-routing-key' => $routingKey ?? '',
+            ]),
+        );
 
-            $this->channel()->queue_bind(
-                queue: $delayQueueName,
-                exchange: $this->connectionConfig->delay->exchange->name,
-                routing_key: $delayQueueName,
-                nowait: false,
-            );
-        } catch (AMQPExceptionInterface $e) {
-            throw new TransportException($e->getMessage(), 0, $e);
-        }
+        $this->channel()->queue_bind(
+            queue: $delayQueueName,
+            exchange: $this->connectionConfig->delay->exchange->name,
+            routing_key: $delayQueueName,
+            nowait: false,
+        );
     }
 
     /** @throws AMQPExceptionInterface */

--- a/tests/Transport/ConnectionTest.php
+++ b/tests/Transport/ConnectionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Jwage\PhpAmqpLibMessengerBundle\Tests\Transport;
 
+use Jwage\PhpAmqpLibMessengerBundle\Retry;
 use Jwage\PhpAmqpLibMessengerBundle\RetryFactory;
 use Jwage\PhpAmqpLibMessengerBundle\Tests\TestCase;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpConnectionFactory;
@@ -317,6 +318,8 @@ class ConnectionTest extends TestCase
     {
         [$connection, $amqpConnection, $amqpChannel] = $this->createConnectionWithAllMocks();
 
+        $amqpConnection->method('isConnected')->willReturn(true);
+
         $amqpConnection->expects(self::once())
             ->method('channel')
             ->willReturn($amqpChannel);
@@ -333,6 +336,8 @@ class ConnectionTest extends TestCase
         [$connection, $amqpConnection, $amqpChannel] = $this->createConnectionWithAllMocks(
             new ConnectionConfig(confirmEnabled: false),
         );
+
+        $amqpConnection->method('isConnected')->willReturn(true);
 
         $amqpConnection->expects(self::once())
             ->method('channel')
@@ -590,6 +595,118 @@ class ConnectionTest extends TestCase
         $this->connection->retry(static function (): void {
             throw new AMQPConnectionClosedException('test');
         }, waitTime: 0)->run();
+    }
+
+    public function testChannelInvalidatesCachedChannelWhenConnectionClosed(): void
+    {
+        [$connection, $amqpConnection, $amqpChannel1] = $this->createConnectionWithAllMocks();
+
+        $amqpChannel2 = $this->createMock(AMQPChannel::class);
+
+        $amqpConnection->expects(self::exactly(2))
+            ->method('channel')
+            ->willReturnOnConsecutiveCalls($amqpChannel1, $amqpChannel2);
+
+        $amqpConnection->method('isConnected')
+            ->willReturn(false);
+
+        $amqpChannel1->expects(self::once())
+            ->method('confirm_select');
+
+        $amqpChannel2->expects(self::once())
+            ->method('confirm_select');
+
+        self::assertSame($amqpChannel1, $connection->channel());
+        self::assertSame($amqpChannel2, $connection->channel());
+    }
+
+    public function testPublishWithDelayReconnectsOnStaleConnection(): void
+    {
+        $connectionConfig = new ConnectionConfig(
+            autoSetup: false,
+            confirmEnabled: true,
+            confirmTimeout: 5.0,
+            exchange: new ExchangeConfig(name: 'exchange_name'),
+            queues: [
+                'queue_name' => new QueueConfig(name: 'queue_name'),
+            ],
+        );
+
+        $factory        = $this->createStub(AmqpConnectionFactory::class);
+        $amqpConnection = $this->createMock(AMQPStreamConnection::class);
+        $amqpChannel1   = $this->createMock(AMQPChannel::class);
+        $amqpChannel2   = $this->createMock(AMQPChannel::class);
+
+        $factory->method('create')->willReturn($amqpConnection);
+        $amqpConnection->method('isConnected')->willReturn(true);
+        $amqpConnection->expects(self::exactly(2))
+            ->method('channel')
+            ->willReturnOnConsecutiveCalls($amqpChannel1, $amqpChannel2);
+        $amqpConnection->expects(self::once())
+            ->method('reconnect');
+
+        $delayQueueName = $connectionConfig->getDelayQueueName(5000, '', false);
+
+        $amqpChannel1->method('confirm_select');
+        $amqpChannel2->method('confirm_select');
+
+        $connection = new Connection(
+            retryFactory: new RetryFactory(),
+            amqpConnectionFactory: $factory,
+            connectionConfig: $connectionConfig,
+        );
+
+        $connection->channel();
+
+        $amqpChannel1->expects(self::once())
+            ->method('exchange_declare');
+
+        $amqpChannel1->expects(self::once())
+            ->method('queue_declare')
+            ->willThrowException(new AMQPConnectionClosedException('Broken pipe or closed connection'));
+
+        $amqpChannel2->expects(self::once())
+            ->method('queue_declare')
+            ->with(
+                queue: $delayQueueName,
+                passive: false,
+                durable: false,
+                exclusive: false,
+                auto_delete: true,
+                nowait: false,
+                arguments: new AMQPTable([
+                    'x-message-ttl' => 5000,
+                    'x-expires' => 15000,
+                    'x-dead-letter-exchange' => 'exchange_name',
+                    'x-dead-letter-routing-key' => '',
+                ]),
+            )
+            ->willReturn([$delayQueueName, 0]);
+
+        $amqpChannel2->expects(self::once())
+            ->method('queue_bind')
+            ->with(
+                queue: $delayQueueName,
+                exchange: 'delays',
+                routing_key: $delayQueueName,
+                nowait: false,
+            );
+
+        $amqpChannel2->expects(self::once())
+            ->method('basic_publish');
+
+        $amqpChannel2->expects(self::once())
+            ->method('wait_for_pending_acks')
+            ->with(timeout: 5);
+
+        $previousWaitTime       = Retry::$defaultWaitTime;
+        Retry::$defaultWaitTime = 0;
+
+        try {
+            $connection->publish(body: 'test body', delayInMs: 5000);
+        } finally {
+            Retry::$defaultWaitTime = $previousWaitTime;
+        }
     }
 
     protected function setUp(): void

--- a/tests/Transport/ConnectionTest.php
+++ b/tests/Transport/ConnectionTest.php
@@ -18,6 +18,7 @@ use Jwage\PhpAmqpLibMessengerBundle\Transport\Config\QueueConfig;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\Connection;
 use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Exception\AMQPChannelClosedException;
 use PhpAmqpLib\Exception\AMQPConnectionClosedException;
 use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Wire\AMQPTable;
@@ -121,6 +122,108 @@ class ConnectionTest extends TestCase
         );
 
         return [$connection, $amqpConnection, $amqpChannel];
+    }
+
+    /**
+     * @return array{
+     *     0: Connection,
+     *     1: AMQPStreamConnection&MockObject,
+     *     2: AMQPChannel&MockObject,
+     *     3: AMQPChannel&MockObject,
+     *     4: string,
+     * }
+     */
+    private function createConnectionForDelayPublishReconnectTest(
+        ConnectionConfig|null $connectionConfig = null,
+    ): array {
+        $connectionConfig ??= new ConnectionConfig(
+            autoSetup: false,
+            confirmEnabled: true,
+            confirmTimeout: 5.0,
+            exchange: new ExchangeConfig(name: 'exchange_name'),
+            queues: [
+                'queue_name' => new QueueConfig(name: 'queue_name'),
+            ],
+        );
+
+        $factory        = $this->createStub(AmqpConnectionFactory::class);
+        $amqpConnection = $this->createMock(AMQPStreamConnection::class);
+        $amqpChannel1   = $this->createMock(AMQPChannel::class);
+        $amqpChannel2   = $this->createMock(AMQPChannel::class);
+
+        $factory->method('create')->willReturn($amqpConnection);
+        $amqpConnection->method('isConnected')->willReturn(true);
+        $amqpConnection->expects(self::exactly(2))
+            ->method('channel')
+            ->willReturnOnConsecutiveCalls($amqpChannel1, $amqpChannel2);
+        $amqpConnection->expects(self::once())
+            ->method('reconnect');
+
+        $amqpChannel1->method('confirm_select');
+        $amqpChannel2->method('confirm_select');
+
+        $connection = new Connection(
+            retryFactory: new RetryFactory(),
+            amqpConnectionFactory: $factory,
+            connectionConfig: $connectionConfig,
+        );
+
+        $connection->channel();
+
+        $delayQueueName = $connectionConfig->getDelayQueueName(5000, '', false);
+
+        return [$connection, $amqpConnection, $amqpChannel1, $amqpChannel2, $delayQueueName];
+    }
+
+    private function expectSuccessfulDelayQueueSetupOnChannel(
+        AMQPChannel&MockObject $amqpChannel,
+        string $delayQueueName,
+    ): void {
+        $amqpChannel->expects(self::once())
+            ->method('queue_declare')
+            ->with(
+                queue: $delayQueueName,
+                passive: false,
+                durable: false,
+                exclusive: false,
+                auto_delete: true,
+                nowait: false,
+                arguments: new AMQPTable([
+                    'x-message-ttl' => 5000,
+                    'x-expires' => 15000,
+                    'x-dead-letter-exchange' => 'exchange_name',
+                    'x-dead-letter-routing-key' => '',
+                ]),
+            )
+            ->willReturn([$delayQueueName, 0]);
+
+        $amqpChannel->expects(self::once())
+            ->method('queue_bind')
+            ->with(
+                queue: $delayQueueName,
+                exchange: 'delays',
+                routing_key: $delayQueueName,
+                nowait: false,
+            );
+
+        $amqpChannel->expects(self::once())
+            ->method('basic_publish');
+
+        $amqpChannel->expects(self::once())
+            ->method('wait_for_pending_acks')
+            ->with(timeout: 5);
+    }
+
+    private function runDelayPublishWithZeroWaitTime(Connection $connection): void
+    {
+        $previousWaitTime       = Retry::$defaultWaitTime;
+        Retry::$defaultWaitTime = 0;
+
+        try {
+            $connection->publish(body: 'test body', delayInMs: 5000);
+        } finally {
+            Retry::$defaultWaitTime = $previousWaitTime;
+        }
     }
 
     private function getDefaultConfig(): ConnectionConfig
@@ -622,41 +725,7 @@ class ConnectionTest extends TestCase
 
     public function testPublishWithDelayReconnectsOnStaleConnection(): void
     {
-        $connectionConfig = new ConnectionConfig(
-            autoSetup: false,
-            confirmEnabled: true,
-            confirmTimeout: 5.0,
-            exchange: new ExchangeConfig(name: 'exchange_name'),
-            queues: [
-                'queue_name' => new QueueConfig(name: 'queue_name'),
-            ],
-        );
-
-        $factory        = $this->createStub(AmqpConnectionFactory::class);
-        $amqpConnection = $this->createMock(AMQPStreamConnection::class);
-        $amqpChannel1   = $this->createMock(AMQPChannel::class);
-        $amqpChannel2   = $this->createMock(AMQPChannel::class);
-
-        $factory->method('create')->willReturn($amqpConnection);
-        $amqpConnection->method('isConnected')->willReturn(true);
-        $amqpConnection->expects(self::exactly(2))
-            ->method('channel')
-            ->willReturnOnConsecutiveCalls($amqpChannel1, $amqpChannel2);
-        $amqpConnection->expects(self::once())
-            ->method('reconnect');
-
-        $delayQueueName = $connectionConfig->getDelayQueueName(5000, '', false);
-
-        $amqpChannel1->method('confirm_select');
-        $amqpChannel2->method('confirm_select');
-
-        $connection = new Connection(
-            retryFactory: new RetryFactory(),
-            amqpConnectionFactory: $factory,
-            connectionConfig: $connectionConfig,
-        );
-
-        $connection->channel();
+        [$connection, , $amqpChannel1, $amqpChannel2, $delayQueueName] = $this->createConnectionForDelayPublishReconnectTest();
 
         $amqpChannel1->expects(self::once())
             ->method('exchange_declare');
@@ -665,48 +734,74 @@ class ConnectionTest extends TestCase
             ->method('queue_declare')
             ->willThrowException(new AMQPConnectionClosedException('Broken pipe or closed connection'));
 
-        $amqpChannel2->expects(self::once())
+        $this->expectSuccessfulDelayQueueSetupOnChannel($amqpChannel2, $delayQueueName);
+
+        $this->runDelayPublishWithZeroWaitTime($connection);
+    }
+
+    public function testPublishWithDelayReconnectsOnStaleChannelClosedException(): void
+    {
+        [$connection, , $amqpChannel1, $amqpChannel2, $delayQueueName] = $this->createConnectionForDelayPublishReconnectTest();
+
+        $amqpChannel1->expects(self::once())
+            ->method('exchange_declare');
+
+        $amqpChannel1->expects(self::once())
             ->method('queue_declare')
-            ->with(
-                queue: $delayQueueName,
-                passive: false,
-                durable: false,
-                exclusive: false,
-                auto_delete: true,
-                nowait: false,
-                arguments: new AMQPTable([
-                    'x-message-ttl' => 5000,
-                    'x-expires' => 15000,
-                    'x-dead-letter-exchange' => 'exchange_name',
-                    'x-dead-letter-routing-key' => '',
-                ]),
-            )
-            ->willReturn([$delayQueueName, 0]);
+            ->willThrowException(new AMQPChannelClosedException('Channel connection is closed.'));
+
+        $this->expectSuccessfulDelayQueueSetupOnChannel($amqpChannel2, $delayQueueName);
+
+        $this->runDelayPublishWithZeroWaitTime($connection);
+    }
+
+    public function testPublishWithDelayReconnectsWhenExchangeDeclareFailsOnStaleConnection(): void
+    {
+        [$connection, , $amqpChannel1, $amqpChannel2, $delayQueueName] = $this->createConnectionForDelayPublishReconnectTest();
+
+        $amqpChannel1->expects(self::once())
+            ->method('exchange_declare')
+            ->willThrowException(new AMQPConnectionClosedException('Broken pipe or closed connection'));
+
+        $amqpChannel1->expects(self::never())
+            ->method('queue_declare');
 
         $amqpChannel2->expects(self::once())
-            ->method('queue_bind')
-            ->with(
-                queue: $delayQueueName,
-                exchange: 'delays',
-                routing_key: $delayQueueName,
-                nowait: false,
-            );
+            ->method('exchange_declare');
 
-        $amqpChannel2->expects(self::once())
-            ->method('basic_publish');
+        $this->expectSuccessfulDelayQueueSetupOnChannel($amqpChannel2, $delayQueueName);
 
-        $amqpChannel2->expects(self::once())
-            ->method('wait_for_pending_acks')
-            ->with(timeout: 5);
+        $this->runDelayPublishWithZeroWaitTime($connection);
+    }
 
-        $previousWaitTime       = Retry::$defaultWaitTime;
-        Retry::$defaultWaitTime = 0;
+    public function testPublishWithDelayReconnectsWhenAutoSetupDelayDisabled(): void
+    {
+        [$connection, , $amqpChannel1, $amqpChannel2, $delayQueueName] = $this->createConnectionForDelayPublishReconnectTest(
+            new ConnectionConfig(
+                autoSetup: false,
+                confirmEnabled: true,
+                confirmTimeout: 5.0,
+                exchange: new ExchangeConfig(name: 'exchange_name'),
+                delay: new DelayConfig(autoSetup: false),
+                queues: [
+                    'queue_name' => new QueueConfig(name: 'queue_name'),
+                ],
+            ),
+        );
 
-        try {
-            $connection->publish(body: 'test body', delayInMs: 5000);
-        } finally {
-            Retry::$defaultWaitTime = $previousWaitTime;
-        }
+        $amqpChannel1->expects(self::never())
+            ->method('exchange_declare');
+
+        $amqpChannel1->expects(self::once())
+            ->method('queue_declare')
+            ->willThrowException(new AMQPConnectionClosedException('Broken pipe or closed connection'));
+
+        $amqpChannel2->expects(self::never())
+            ->method('exchange_declare');
+
+        $this->expectSuccessfulDelayQueueSetupOnChannel($amqpChannel2, $delayQueueName);
+
+        $this->runDelayPublishWithZeroWaitTime($connection);
     }
 
     protected function setUp(): void


### PR DESCRIPTION
## Summary

Fixes production failures when Symfony Messenger workers publish delayed messages (`delayInMs > 0`) after slow handler work leaves the AMQP connection stale.

**Problem:** Workers cache an AMQP channel while consuming. After long handler work (broker API calls, DB flushes, etc.), the connection can die. Publishing a delayed follow-up message then fails in `setupDelayQueue()` → `queue_declare()` with errors like:

- `Broken pipe or closed connection` (`AMQPConnectionClosedException`)
- `Channel connection is closed.` (`AMQPChannelClosedException`)

Unlike `basic_publish`, delay exchange/queue setup was **not** wrapped in `retryWithReconnect()`, and `setupDelayQueue()` converted AMQP exceptions to `TransportException` before `RetryFactory` could retry.

**Changes:**

- Wrap `setupDelayExchangeAndQueue()` in `retryWithReconnect()` (same pattern as `basic_publish`)
- Let AMQP exceptions propagate from `setupDelayExchange()` / `setupDelayQueue()` so `RetryFactory` can reconnect and retry
- Keep `TransportException` conversion on the explicit `setup()` path only
- Invalidate cached channel in `channel()` when `!isConnected()`
- Add/expand `ConnectionTest` coverage for stale-connection delay publish scenarios
- Psalm: document `TransportException` on delay setup methods; suppress `DeprecatedInterface` on bundle class (Symfony 8.1 `BundleInterface` deprecation)
