### PR TITLE
Fix: Propagate stamps in batch bus

### DIFF
--- a/src/Batch.php
+++ b/src/Batch.php
@@ -11,6 +11,7 @@ use Override;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
+use function array_values;
 use function spl_object_id;
 
 class Batch implements MessageBusInterface
@@ -38,7 +39,7 @@ class Batch implements MessageBusInterface
     #[Override]
     public function dispatch(object $message, array $stamps = []): Envelope
     {
-        $envelope = Envelope::wrap($message)
+        $envelope = Envelope::wrap($message, array_values($stamps))
             ->with(new DeferrableStamp($this->batchSize));
 
         $envelope = $this->wrappedBus->dispatch($envelope);

--- a/tests/BatchTest.php
+++ b/tests/BatchTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 
 class BatchTest extends TestCase
 {
@@ -46,6 +47,21 @@ class BatchTest extends TestCase
         $this->batch->dispatch($message2);
 
         $this->batch->flush();
+    }
+
+    public function testPropagateStamps(): void
+    {
+        $message = new stdClass();
+        $stamp   = new DelayStamp(1234);
+
+        $this->wrappedBus->expects(self::once())
+            ->method('dispatch')
+            ->with($this->isInstanceOf(Envelope::class))
+            ->willReturnArgument(0);
+
+        $envelope = $this->batch->dispatch($message, [$stamp]);
+
+        $this->assertSame($stamp, $envelope->last($stamp::class));
     }
 
     public function testFlushTransportOncePerBatch(): void


### PR DESCRIPTION
Fixing what is probably just a simple oversight