### PR TITLE
Declare delay queue as durable/non-auto-delete

### DIFF
--- a/src/Transport/Connection.php
+++ b/src/Transport/Connection.php
@@ -458,6 +458,10 @@ class Connection
 
         $this->channel()->queue_declare(
             queue: $delayQueueName,
+            passive: false,
+            durable: true,
+            exclusive: false,
+            auto_delete: false,
             nowait: false,
             arguments: new AMQPTable([
                 'x-message-ttl' => $delay,

--- a/tests/Transport/ConnectionTest.php
+++ b/tests/Transport/ConnectionTest.php
@@ -184,9 +184,9 @@ class ConnectionTest extends TestCase
             ->with(
                 queue: $delayQueueName,
                 passive: false,
-                durable: false,
+                durable: true,
                 exclusive: false,
-                auto_delete: true,
+                auto_delete: false,
                 nowait: false,
                 arguments: new AMQPTable([
                     'x-message-ttl' => 5000,


### PR DESCRIPTION
Fixes #125.

## Problem

`Connection::setupDelayQueue()` declares the per-message delay queue without passing `durable`/`exclusive`/`auto_delete`, so it falls back to `php-amqplib`'s `queue_declare()` defaults: `durable=false`, `exclusive=false`, `auto_delete=true` — i.e. a transient, non-exclusive queue.

RabbitMQ 4.x gates that exact combination behind the deprecated `transient_nonexcl_queues` feature flag, which is on a path to removal in a future major version. Once an operator disables it (`deprecated_features.permit.transient_nonexcl_queues = false`), every delay-queue declaration fails and delayed message publishing breaks outright.

## Fix

Declare the delay queue explicitly as `durable: true, auto_delete: false` (matching the style already used for the regular queues and the delay exchange a few lines above/below).

The queue already carries `x-expires` (`$delay + 10000`), so it still self-deletes shortly after going idle — durability doesn't change its lifecycle, it just avoids depending on the deprecated queue class.

## Test plan

- [x] Updated `ConnectionTest::expectSuccessfulDelayQueueSetupOnChannel()` to assert the new `durable`/`auto_delete` values.
- [x] `vendor/bin/phpunit` — all `ConnectionTest` cases pass (25/25); the only failures in the full suite are `TransportFunctionalTest`, which needs a live broker connection and is unrelated to this change.
- [x] `vendor/bin/psalm` — no errors.
- [x] `vendor/bin/phpcs` — no errors.

Happy to add a CHANGELOG entry or adjust naming/style if you'd prefer a different approach.