### PR TITLE
Subscribe to every queue on a single transport

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,8 @@ bin/console messenger:consume transport2
 
 Because we're using a blocking consumer, when you pass multiple transports to the `messenger:consume` command, the first transport will block the process and wait for messages for the configured `queueConfig.waitTimeout` value before the second transport will start consuming messages. This maybe could be enhanced to work better in the future, but we believe something would have to be changed in the Symfony Messenger component to support this. For now, we recommend consuming messages from each transport in a separate process.
 
+A single transport can declare multiple queues. The receiver subscribes to each queue rather than only the first. Those queues are still polled sequentially: `consume()` waits up to that queue's `wait_timeout` before the next queue is polled. Messages that arrive for another already-subscribed queue during that wait are buffered and returned when that queue is polled.
+
 ## Minimum Configuration
 
 The minimum configuration requires a transport name and DSN.
@@ -263,7 +265,7 @@ Pending batches exist only in process memory. They do not survive process termin
 
 ## Publisher and Consumer Channels
 
-Publishing/topology operations and consuming use separate AMQP channels, even when they share one underlying connection. A live publisher-channel failure can therefore be retired and replaced without invalidating an in-flight consumer delivery tag. If the underlying connection dies, its delivery tags are no longer valid and the transport re-registers the consumer on a fresh channel. `Connection::channel()` returns the publisher/topology channel; use the transport receiver or `Connection::consume()` for consumption.
+Publishing/topology operations and consuming use separate AMQP channels, even when they share one underlying connection. A live publisher-channel failure can therefore be retired and replaced without invalidating an in-flight consumer delivery tag. If the underlying connection dies, its delivery tags are no longer valid and the transport re-registers its consumers on a fresh channel. `Connection::channel()` returns the publisher/topology channel; use the transport receiver or `Connection::consume()` for consumption.
 
 When RabbitMQ reports a resource alarm, known-blocked publishes fail before allocating another channel. A publisher channel that discovers the alarm is reclaimed after the connection becomes readable again and before its replacement is opened.
 

--- a/src/Transport/Connection.php
+++ b/src/Transport/Connection.php
@@ -40,7 +40,8 @@ class Connection
     /** @var list<AMQPChannel> */
     private array $retiredPublisherChannels = [];
 
-    private AmqpConsumer|null $consumer = null;
+    /** @var array<string, AmqpConsumer> */
+    private array $consumers = [];
 
     /** @var list<array{0: AMQPMessage, 1: string, 2: string}> */
     private array $batchMessages = [];
@@ -63,12 +64,12 @@ class Connection
 
     public function __destruct()
     {
-        $this->consumer?->invalidate();
+        $this->invalidateConsumers();
 
         $this->connection      = null;
         $this->channel         = null;
         $this->consumerChannel = null;
-        $this->consumer        = null;
+        $this->consumers       = [];
 
         $this->pendingBatchConfirmChannel = null;
         $this->retiredPublisherChannels   = [];
@@ -90,13 +91,13 @@ class Connection
             // Closing the connection cancels its consumers, so do not issue a separate
             // basic_cancel first. Besides being redundant, that round trip can block on
             // an alarm-blocked connection or reconnect solely to cancel a stale tag.
-            $this->consumer?->invalidate();
+            $this->invalidateConsumers();
             $this->connection?->close();
         } finally {
             $this->connection      = null;
             $this->channel         = null;
             $this->consumerChannel = null;
-            $this->consumer        = null;
+            $this->consumers       = [];
 
             $this->pendingBatchConfirmChannel = null;
             $this->retiredPublisherChannels   = [];
@@ -169,7 +170,7 @@ class Connection
     }
 
     /**
-     * Returns the channel reserved for the transport-managed consumer.
+     * Returns the channel reserved for transport-managed consumers.
      *
      * @internal AmqpConsumer owns registrations and local state on this channel.
      *
@@ -183,7 +184,7 @@ class Connection
 
         if ($this->consumerChannel !== null && ! $this->consumerChannel->is_open()) {
             $this->consumerChannel = null;
-            $this->consumer?->invalidate();
+            $this->invalidateConsumers();
         }
 
         if ($this->consumerChannel === null) {
@@ -211,7 +212,7 @@ class Connection
             $this->setupExchangeAndQueues();
         }
 
-        return ($this->consumer ??= new AmqpConsumer($this, $this->connectionConfig, $this->logger))->consume($queueName);
+        return ($this->consumers[$queueName] ??= new AmqpConsumer($this, $this->connectionConfig, $this->logger))->consume($queueName);
     }
 
     /**
@@ -564,7 +565,7 @@ class Connection
         $this->consumerChannel            = null;
         $this->pendingBatchConfirmChannel = null;
         $this->retiredPublisherChannels   = [];
-        $this->consumer?->invalidate();
+        $this->invalidateConsumers();
 
         foreach ($channels as $channel) {
             $channel?->closeIfDisconnected();
@@ -651,6 +652,13 @@ class Connection
 
         if ($connection->isBlocked()) {
             throw new AMQPConnectionBlockedException();
+        }
+    }
+
+    private function invalidateConsumers(): void
+    {
+        foreach ($this->consumers as $consumer) {
+            $consumer->invalidate();
         }
     }
 

--- a/tests/TestKernel.php
+++ b/tests/TestKernel.php
@@ -87,6 +87,26 @@ class TestKernel extends Kernel implements CompilerPassInterface
                                 ],
                             ],
                         ],
+                        'with_multiple_queues' => [
+                            'dsn' => '%env(MESSENGER_TRANSPORT_PHPAMQPLIB_DSN)%',
+                            'options' => [
+                                'transactions_enabled' => false,
+                                'confirm_enabled' => true,
+                                'wait_timeout' => 0.10, // lower wait_timeout for tests
+                                'exchange' => [
+                                    'name' => 'test_multiple_queues_exchange',
+                                    'type' => 'direct',
+                                ],
+                                'queues' => [
+                                    'test_multiple_queues_order' => [
+                                        'binding_keys' => ['order'],
+                                    ],
+                                    'test_multiple_queues_quote' => [
+                                        'binding_keys' => ['quote'],
+                                    ],
+                                ],
+                            ],
+                        ],
                     ],
                     'routing' => [
                         ConfirmMessage::class => 'with_confirms',

--- a/tests/Transport/AmqpReceiverTest.php
+++ b/tests/Transport/AmqpReceiverTest.php
@@ -84,6 +84,57 @@ class AmqpReceiverTest extends TestCase
         self::assertSame('queue_name', $amqpReceivedStamp1->getQueueName());
     }
 
+    public function testGetConsumesEachConfiguredQueue(): void
+    {
+        $message1      = new stdClass();
+        $message2      = new stdClass();
+        $envelope1     = new Envelope($message1);
+        $envelope2     = new Envelope($message2);
+        $amqpEnvelope1 = new AmqpEnvelope(new AMQPMessage(serialize($message1), ['message_id' => '1']));
+        $amqpEnvelope2 = new AmqpEnvelope(new AMQPMessage(serialize($message2), ['message_id' => '2']));
+
+        $connection = $this->getTestConnection();
+        $connection->method('getQueueNames')
+            ->willReturn(['queue_name', 'queue_name2']);
+
+        $connection->expects(self::exactly(2))
+            ->method('consume')
+            ->willReturnCallback(
+                static function (string $queueName) use ($amqpEnvelope1, $amqpEnvelope2): array {
+                    return match ($queueName) {
+                        'queue_name' => [$amqpEnvelope1],
+                        'queue_name2' => [$amqpEnvelope2],
+                        default => [],
+                    };
+                },
+            );
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects(self::exactly(2))
+            ->method('decode')
+            ->willReturnOnConsecutiveCalls($envelope1, $envelope2);
+
+        $receiver = new AmqpReceiver($connection, $serializer);
+
+        $envelopes = [];
+
+        foreach ($receiver->get() as $envelope) {
+            $envelopes[] = $envelope;
+        }
+
+        self::assertCount(2, $envelopes);
+
+        $amqpReceivedStamp1 = $envelopes[0]->last(AmqpReceivedStamp::class);
+        $amqpReceivedStamp2 = $envelopes[1]->last(AmqpReceivedStamp::class);
+
+        self::assertInstanceOf(AmqpReceivedStamp::class, $amqpReceivedStamp1);
+        self::assertInstanceOf(AmqpReceivedStamp::class, $amqpReceivedStamp2);
+        self::assertSame($amqpEnvelope1, $amqpReceivedStamp1->getAMQPEnvelope());
+        self::assertSame('queue_name', $amqpReceivedStamp1->getQueueName());
+        self::assertSame($amqpEnvelope2, $amqpReceivedStamp2->getAMQPEnvelope());
+        self::assertSame('queue_name2', $amqpReceivedStamp2->getQueueName());
+    }
+
     public function testGetNacksWhenDecodeThrows(): void
     {
         $amqpEnvelope = $this->createMock(AmqpEnvelope::class);

--- a/tests/Transport/ConnectionTest.php
+++ b/tests/Transport/ConnectionTest.php
@@ -421,6 +421,17 @@ class ConnectionTest extends TestCase
         );
     }
 
+    private function getConsumer(Connection $connection, string $queueName = 'queue_name'): AmqpConsumer
+    {
+        $consumers = (new ReflectionProperty(Connection::class, 'consumers'))->getValue($connection);
+        assert(is_array($consumers));
+
+        $consumer = $consumers[$queueName] ?? null;
+        assert($consumer instanceof AmqpConsumer);
+
+        return $consumer;
+    }
+
     public function testClose(): void
     {
         [$connection, $amqpConnection] = $this->createConnectionWithConnectionMock();
@@ -486,8 +497,7 @@ class ConnectionTest extends TestCase
 
         self::assertSame([], iterator_to_array($envelopes));
 
-        $consumer = (new ReflectionProperty(Connection::class, 'consumer'))->getValue($connection);
-        assert($consumer instanceof AmqpConsumer);
+        $consumer = $this->getConsumer($connection);
 
         $consumerTagProperty = new ReflectionProperty(AmqpConsumer::class, 'consumerTag');
         self::assertSame('consumer-tag', $consumerTagProperty->getValue($consumer));
@@ -670,8 +680,7 @@ class ConnectionTest extends TestCase
 
         self::assertSame([], iterator_to_array($envelopes));
 
-        $consumer = (new ReflectionProperty(Connection::class, 'consumer'))->getValue($connection);
-        assert($consumer instanceof AmqpConsumer);
+        $consumer = $this->getConsumer($connection);
 
         // Simulate a delivery already received on the consumer channel.
         $bufferProperty = new ReflectionProperty(AmqpConsumer::class, 'buffer');
@@ -761,8 +770,7 @@ class ConnectionTest extends TestCase
         $envelopes = $connection->consume('queue_name');
         self::assertSame([], iterator_to_array($envelopes));
 
-        $consumer = (new ReflectionProperty(Connection::class, 'consumer'))->getValue($connection);
-        assert($consumer instanceof AmqpConsumer);
+        $consumer = $this->getConsumer($connection);
 
         $message = new AMQPMessage('in-flight delivery');
         $message->setChannel($consumerChannel);
@@ -852,8 +860,7 @@ class ConnectionTest extends TestCase
         $envelopes = $connection->consume('queue_name');
         self::assertSame([], iterator_to_array($envelopes));
 
-        $consumer = (new ReflectionProperty(Connection::class, 'consumer'))->getValue($connection);
-        assert($consumer instanceof AmqpConsumer);
+        $consumer = $this->getConsumer($connection);
 
         $message = new AMQPMessage('in-flight delivery');
         $message->setChannel($consumerChannel);
@@ -952,8 +959,7 @@ class ConnectionTest extends TestCase
 
         self::assertSame([], iterator_to_array($envelopes));
 
-        $consumer = (new ReflectionProperty(Connection::class, 'consumer'))->getValue($connection);
-        assert($consumer instanceof AmqpConsumer);
+        $consumer = $this->getConsumer($connection);
         $consumer->invalidate();
     }
 
@@ -1007,8 +1013,7 @@ class ConnectionTest extends TestCase
         $envelopes = $connection->consume('queue_name');
         self::assertSame([], iterator_to_array($envelopes));
 
-        $consumer = (new ReflectionProperty(Connection::class, 'consumer'))->getValue($connection);
-        assert($consumer instanceof AmqpConsumer);
+        $consumer = $this->getConsumer($connection);
         $consumer->callback(new AMQPMessage('stale delivery'));
 
         $channel1Open = false;
@@ -1224,6 +1229,80 @@ class ConnectionTest extends TestCase
         $amqpEnvelopes = $this->connection->consume('queue_name');
 
         self::assertCount(0, iterator_to_array($amqpEnvelopes));
+    }
+
+    public function testConsumeRegistersASeparateConsumerPerQueue(): void
+    {
+        $connectionConfig = new ConnectionConfig(
+            autoSetup: false,
+            confirmEnabled: false,
+            queues: [
+                'queue_name' => new QueueConfig(name: 'queue_name'),
+                'queue_name2' => new QueueConfig(name: 'queue_name2'),
+            ],
+        );
+
+        $factory        = $this->createMock(AmqpConnectionFactory::class);
+        $amqpConnection = $this->createMock(AMQPStreamConnection::class);
+        $amqpChannel    = $this->createMock(AMQPChannel::class);
+
+        $factory->expects(self::once())
+            ->method('create')
+            ->willReturn($amqpConnection);
+
+        $amqpConnection->expects(self::once())
+            ->method('channel')
+            ->willReturn($amqpChannel);
+        $amqpConnection->method('isConnected')->willReturn(true);
+        $amqpConnection->expects(self::once())
+            ->method('close');
+
+        $consumedQueues = [];
+
+        $amqpChannel->method('is_open')->willReturn(true);
+        $amqpChannel->method('is_consuming')->willReturn(true);
+        $amqpChannel->method('wait')->willThrowException(new AMQPTimeoutException('poll timeout'));
+        $amqpChannel->expects(self::never())
+            ->method('basic_cancel');
+        $amqpChannel->expects(self::exactly(2))
+            ->method('basic_consume')
+            ->willReturnCallback(
+                static function (string $queue, mixed ...$_args) use (&$consumedQueues): string {
+                    $consumedQueues[] = $queue;
+
+                    return $queue === 'queue_name' ? 'consumer-tag-1' : 'consumer-tag-2';
+                },
+            );
+
+        $connection = new Connection(
+            retryFactory: new RetryFactory(),
+            amqpConnectionFactory: $factory,
+            connectionConfig: $connectionConfig,
+        );
+
+        /** @var Traversable<AmqpEnvelope> $envelopes */
+        $envelopes = $connection->consume('queue_name');
+        self::assertSame([], iterator_to_array($envelopes));
+
+        /** @var Traversable<AmqpEnvelope> $envelopes */
+        $envelopes = $connection->consume('queue_name2');
+        self::assertSame([], iterator_to_array($envelopes));
+
+        self::assertSame(['queue_name', 'queue_name2'], $consumedQueues);
+
+        $consumer1 = $this->getConsumer($connection, 'queue_name');
+        $consumer2 = $this->getConsumer($connection, 'queue_name2');
+
+        self::assertNotSame($consumer1, $consumer2);
+
+        $consumerTagProperty = new ReflectionProperty(AmqpConsumer::class, 'consumerTag');
+        self::assertSame('consumer-tag-1', $consumerTagProperty->getValue($consumer1));
+        self::assertSame('consumer-tag-2', $consumerTagProperty->getValue($consumer2));
+
+        $connection->close();
+
+        self::assertNull($consumerTagProperty->getValue($consumer1));
+        self::assertNull($consumerTagProperty->getValue($consumer2));
     }
 
     public function testPublish(): void

--- a/tests/TransportFunctionalTest.php
+++ b/tests/TransportFunctionalTest.php
@@ -44,6 +44,8 @@ class TransportFunctionalTest extends KernelTestCase
 
     private AmqpTransport $transactionsTransport;
 
+    private AmqpTransport $multipleQueuesTransport;
+
     public function testTransportWithConfirms(): void
     {
         $envelopes = $this->getEnvelopes($this->confirmsTransport, 0);
@@ -129,6 +131,64 @@ class TransportFunctionalTest extends KernelTestCase
         self::assertEquals($message1, $envelopes[0]->getMessage());
         self::assertEquals($message2, $envelopes[1]->getMessage());
         self::assertEquals($message3, $envelopes[2]->getMessage());
+    }
+
+    public function testTransportConsumesFromEveryConfiguredQueue(): void
+    {
+        $this->multipleQueuesTransport->send(
+            Envelope::wrap(new ConfirmMessage(1401))->with(new AmqpStamp(routingKey: 'order')),
+        );
+        $this->multipleQueuesTransport->send(
+            Envelope::wrap(new ConfirmMessage(1402))->with(new AmqpStamp(routingKey: 'quote')),
+        );
+
+        $envelopes = $this->getEnvelopes($this->multipleQueuesTransport, 2);
+
+        $byQueue = [];
+
+        foreach ($envelopes as $envelope) {
+            $stamp = $envelope->last(AmqpReceivedStamp::class);
+            self::assertInstanceOf(AmqpReceivedStamp::class, $stamp);
+
+            $byQueue[$stamp->getQueueName()] = $envelope->getMessage();
+        }
+
+        self::assertEquals(new ConfirmMessage(1401), $byQueue['test_multiple_queues_order'] ?? null);
+        self::assertEquals(new ConfirmMessage(1402), $byQueue['test_multiple_queues_quote'] ?? null);
+    }
+
+    public function testConsumingOneQueueDoesNotPreventConsumingAnother(): void
+    {
+        $this->multipleQueuesTransport->send(
+            Envelope::wrap(new ConfirmMessage(1403))->with(new AmqpStamp(routingKey: 'order')),
+        );
+        $this->multipleQueuesTransport->send(
+            Envelope::wrap(new ConfirmMessage(1404))->with(new AmqpStamp(routingKey: 'quote')),
+        );
+
+        $orderEnvelopes = $this->getEnvelopes(
+            $this->multipleQueuesTransport,
+            1,
+            queueNames: ['test_multiple_queues_order'],
+        );
+
+        self::assertSame(1403, $orderEnvelopes[0]->getMessage()->count);
+        self::assertSame(
+            'test_multiple_queues_order',
+            $orderEnvelopes[0]->last(AmqpReceivedStamp::class)?->getQueueName(),
+        );
+
+        $quoteEnvelopes = $this->getEnvelopes(
+            $this->multipleQueuesTransport,
+            1,
+            queueNames: ['test_multiple_queues_quote'],
+        );
+
+        self::assertSame(1404, $quoteEnvelopes[0]->getMessage()->count);
+        self::assertSame(
+            'test_multiple_queues_quote',
+            $quoteEnvelopes[0]->last(AmqpReceivedStamp::class)?->getQueueName(),
+        );
     }
 
     public function testMessageId(): void
@@ -722,16 +782,24 @@ class TransportFunctionalTest extends KernelTestCase
 
         $this->transactionsTransport = $transactionsTransport;
 
+        $multipleQueuesTransport = $container->get('messenger.transport.with_multiple_queues');
+        assert($multipleQueuesTransport instanceof AmqpTransport);
+
+        $this->multipleQueuesTransport = $multipleQueuesTransport;
+
         $this->confirmsTransport->setup();
         $this->transactionsTransport->setup();
+        $this->multipleQueuesTransport->setup();
         $this->drainTransport($this->confirmsTransport);
         $this->drainTransport($this->transactionsTransport);
+        $this->drainTransport($this->multipleQueuesTransport);
     }
 
     protected function tearDown(): void
     {
         $this->confirmsTransport->getConnection()->close();
         $this->transactionsTransport->getConnection()->close();
+        $this->multipleQueuesTransport->getConnection()->close();
     }
 
     /** @param array<object> $messages */
@@ -746,9 +814,17 @@ class TransportFunctionalTest extends KernelTestCase
         $batch->flush();
     }
 
-    /** @return array<Envelope> */
-    private function getEnvelopes(AmqpTransport $transport, int $count, int $maxEmptyPolls = 100): array
-    {
+    /**
+     * @param list<string>|null $queueNames
+     *
+     * @return array<Envelope>
+     */
+    private function getEnvelopes(
+        AmqpTransport $transport,
+        int $count,
+        int $maxEmptyPolls = 100,
+        array|null $queueNames = null,
+    ): array {
         if ($count === 0) {
             $this->drainTransport($transport);
 
@@ -762,7 +838,9 @@ class TransportFunctionalTest extends KernelTestCase
             $receivedAny = false;
 
             /** @var Traversable<Envelope> $envelopes */
-            $envelopes = $transport->get();
+            $envelopes = $queueNames === null
+                ? $transport->get()
+                : $transport->getFromQueues($queueNames);
 
             foreach ($envelopes as $envelope) {
                 $collectedEnvelopes[] = $envelope;


### PR DESCRIPTION
## Summary
- Ports [#104](https://github.com/jwage/phpamqplib-messenger/pull/104) onto current `main`. That PR cannot be merged: `main` was rewritten, so it has no shared history.
- `AmqpReceiver` already iterates every configured queue, but `Connection` reused one `AmqpConsumer`. Only the first queue received `basic_consume`. Consumers are now keyed by queue name, and close/reconnect still `invalidate()` all of them without `basic_cancel`.
- Documents the remaining sequential poll: each queue still waits up to its `wait_timeout` before the next is polled.

Fixes #103. Supersedes #104.

## Test plan
- [x] `./vendor/bin/phpunit tests/Transport/ConnectionTest.php tests/Transport/AmqpReceiverTest.php tests/Transport/AmqpConsumerTest.php`
- [x] `./vendor/bin/phpcs` on the changed PHP files
- [x] `./vendor/bin/psalm` on `Connection.php`
- [x] CI green on this branch
- [x] Optional: consume a transport with two queues and confirm both show consumers in the RabbitMQ UI


Made with [Cursor](https://cursor.com)