### PR TITLE
Fix: Propagate stamps in batch bus

### DIFF
--- a/src/Batch.php
+++ b/src/Batch.php
@@ -11,6 +11,7 @@ use Override;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 
+use function array_values;
 use function spl_object_id;
 
 class Batch implements MessageBusInterface
@@ -38,7 +39,7 @@ class Batch implements MessageBusInterface
     #[Override]
     public function dispatch(object $message, array $stamps = []): Envelope
     {
-        $envelope = Envelope::wrap($message)
+        $envelope = Envelope::wrap($message, array_values($stamps))
             ->with(new DeferrableStamp($this->batchSize));
 
         $envelope = $this->wrappedBus->dispatch($envelope);

--- a/tests/BatchTest.php
+++ b/tests/BatchTest.php
@@ -7,12 +7,14 @@ namespace Jwage\PhpAmqpLibMessengerBundle\Tests;
 use Jwage\PhpAmqpLibMessengerBundle\Batch;
 use Jwage\PhpAmqpLibMessengerBundle\Stamp\DeferrableStamp;
 use Jwage\PhpAmqpLibMessengerBundle\Stamp\DeferredStamp;
+use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpStamp;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\BatchTransportInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Stamp\StampInterface;
 
 class BatchTest extends TestCase
 {
@@ -49,19 +51,30 @@ class BatchTest extends TestCase
         $this->batch->flush();
     }
 
-    public function testPropagateStamps(): void
+    public function testDispatchPropagatesStamps(): void
     {
-        $message = new stdClass();
-        $stamp   = new DelayStamp(1234);
+        $message    = new stdClass();
+        $delayStamp = new DelayStamp(1234);
+        $amqpStamp  = new AmqpStamp(routingKey: 'orders');
 
-        $this->wrappedBus->expects(self::once())
-            ->method('dispatch')
-            ->with($this->isInstanceOf(Envelope::class))
-            ->willReturnArgument(0);
+        $this->expectWrappedDispatchWithStamps($message, [$delayStamp, $amqpStamp]);
 
-        $envelope = $this->batch->dispatch($message, [$stamp]);
+        $envelope = $this->batch->dispatch($message, [$delayStamp, $amqpStamp]);
 
-        $this->assertSame($stamp, $envelope->last($stamp::class));
+        $this->assertEnvelopeHasMessageAndStamps($envelope, $message, [$delayStamp, $amqpStamp]);
+    }
+
+    public function testDispatchMergesEnvelopeStampsWithDispatchStamps(): void
+    {
+        $message    = new stdClass();
+        $delayStamp = new DelayStamp(1234);
+        $amqpStamp  = new AmqpStamp(routingKey: 'orders');
+
+        $this->expectWrappedDispatchWithStamps($message, [$delayStamp, $amqpStamp]);
+
+        $envelope = $this->batch->dispatch(Envelope::wrap($message, [$delayStamp]), [$amqpStamp]);
+
+        $this->assertEnvelopeHasMessageAndStamps($envelope, $message, [$delayStamp, $amqpStamp]);
     }
 
     public function testFlushTransportOncePerBatch(): void
@@ -134,6 +147,31 @@ class BatchTest extends TestCase
         $this->wrappedBus = $this->createMock(WrappedBus::class);
 
         $this->batch = new Batch($this->wrappedBus, 10);
+    }
+
+    /** @param list<StampInterface> $stamps */
+    private function expectWrappedDispatchWithStamps(object $message, array $stamps): void
+    {
+        $this->wrappedBus->expects(self::once())
+            ->method('dispatch')
+            ->with($this->callback(function (Envelope $envelope) use ($message, $stamps): bool {
+                $this->assertEnvelopeHasMessageAndStamps($envelope, $message, $stamps);
+
+                return true;
+            }))
+            ->willReturnArgument(0);
+    }
+
+    /** @param list<StampInterface> $stamps */
+    private function assertEnvelopeHasMessageAndStamps(Envelope $envelope, object $message, array $stamps): void
+    {
+        self::assertSame($message, $envelope->getMessage());
+
+        foreach ($stamps as $stamp) {
+            self::assertSame($stamp, $envelope->last($stamp::class));
+        }
+
+        self::assertSame(10, $envelope->last(DeferrableStamp::class)?->getBatchSize());
     }
 
     private function createEnvelope(stdClass $message, int $batchSize = 10, BatchTransportInterface|null $transport = null): Envelope

--- a/tests/BatchTest.php
+++ b/tests/BatchTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use stdClass;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
 
 class BatchTest extends TestCase
 {
@@ -46,6 +47,21 @@ class BatchTest extends TestCase
         $this->batch->dispatch($message2);
 
         $this->batch->flush();
+    }
+
+    public function testPropagateStamps(): void
+    {
+        $message = new stdClass();
+        $stamp   = new DelayStamp(1234);
+
+        $this->wrappedBus->expects(self::once())
+            ->method('dispatch')
+            ->with($this->isInstanceOf(Envelope::class))
+            ->willReturnArgument(0);
+
+        $envelope = $this->batch->dispatch($message, [$stamp]);
+
+        $this->assertSame($stamp, $envelope->last($stamp::class));
     }
 
     public function testFlushTransportOncePerBatch(): void


### PR DESCRIPTION
## Summary
- Pass `$stamps` through `Batch::dispatch()` into `Envelope::wrap()` so stamps are no longer dropped (credit: @TamasSzigeti).
- Cover multiple stamps, keep `DeferrableStamp` applied, and merge stamps already on an `Envelope` with the dispatch `$stamps` argument.
- Replaces #123, which could not be updated from this repo (`maintainerCanModify` is off on the fork).

## Test plan
- [x] `vendor/bin/phpunit tests/BatchTest.php`
- [x] `vendor/bin/phpcs tests/BatchTest.php`
- [x] `vendor/bin/psalm tests/BatchTest.php`
- [x] CI matrix on this PR


Made with [Cursor](https://cursor.com)