### PR TITLE
Add fetch_size transport default for older Symfony workers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,24 +31,35 @@ For SSL/TLS connections, use:
 phpamqplibs://username:password@localhost[:port]/vhost[/exchange]
 ```
 
-## Limitations
+## Fetch size and multiple transports
 
-You cannot consume messages from multiple transports at the same time in one `messenger:consume` process. For example, you should not do this:
+This transport honors Symfony Messenger's fetch-size hint on `ReceiverInterface::get()`. That is how many envelopes one Worker `get()` yields before returning; it is not AMQP QoS (`prefetch_count`).
 
-```bash
-bin/console messenger:consume transport1 transport2
+On **Symfony 8.1+**, the Worker always passes a size via `messenger:consume --fetch-size` (default 1). Use that option. Transport `fetch_size` is ignored, because the argument is always present.
+
+On **Symfony < 8.1**, the Worker calls `get()` with no argument. `wait_timeout` only fires when the queue is idle, so a busy transport can yield forever and starve other receivers, `--time-limit`, and `messenger:stop-workers`. Set transport `fetch_size` as the default for that omitted argument:
+
+```yaml
+# config/packages/messenger.yaml
+framework:
+    messenger:
+        transports:
+            orders:
+                dsn: 'phpamqplib://guest:guest@localhost:5672/%2f/orders'
+                options:
+                    fetch_size: 10
 ```
 
-Instead, you should consume messages from each transport in a separate process.
+That yaml value is the same cap as `--fetch-size`, supplied only when the caller does not pass `$fetchSize`. It is not a yaml equivalent of the console option.
+
+The Worker still prefers the first transport listed whenever that transport has work. For isolated throughput, consume each transport in its own process:
 
 ```bash
 bin/console messenger:consume transport1
 bin/console messenger:consume transport2
 ```
 
-Because we're using a blocking consumer, when you pass multiple transports to the `messenger:consume` command, the first transport will block the process and wait for messages for the configured `queueConfig.waitTimeout` value before the second transport will start consuming messages. This maybe could be enhanced to work better in the future, but we believe something would have to be changed in the Symfony Messenger component to support this. For now, we recommend consuming messages from each transport in a separate process.
-
-A single transport can declare multiple queues. The receiver subscribes to each queue rather than only the first. Those queues are still polled sequentially: `consume()` waits up to that queue's `wait_timeout` before the next queue is polled. Messages that arrive for another already-subscribed queue during that wait are buffered and returned when that queue is polled.
+A single transport can declare multiple queues. The receiver subscribes to each queue rather than only the first. Those queues are still polled sequentially: `consume()` waits up to that queue's `wait_timeout` before the next queue is polled. Messages that arrive for another already-subscribed queue during that wait are buffered and returned when that queue is polled. When a fetch size is in effect (CLI argument or transport default), the receiver stops after that many envelopes across those queues.
 
 ## Minimum Configuration
 
@@ -113,8 +124,14 @@ framework:
                     # on consume so the worker can call the transport during processing.
                     keepalive_enabled: false
 
-                    # Prefetch settings
+                    # Prefetch settings (AMQP QoS: max unacked deliveries on the channel)
                     prefetch_count: 1
+
+                    # Default for get() when the caller omits $fetchSize (Symfony < 8.1
+                    # Worker). Same hint as messenger:consume --fetch-size. Omit for
+                    # unlimited. Ignored when get($fetchSize) is passed, including
+                    # Symfony 8.1+ consume which always passes --fetch-size.
+                    fetch_size: 10
 
                     # Consume wait settings
                     wait_timeout: 1
@@ -198,7 +215,10 @@ Any option can be specified in the DSN as an alternative to defining it in the `
 ```
 phpamqplib://guest:guest@localhost?heartbeat=60&read_timeout=5.0
 phpamqplib://guest:guest@localhost?heartbeat=10&keepalive_enabled=true
+phpamqplib://guest:guest@localhost?fetch_size=10
 ```
+
+`fetch_size` on the DSN is the transport default described above, not `messenger:consume --fetch-size`.
 
 `keepalive_enabled=true` has no effect unless `heartbeat` is greater than 0. It also requires Symfony >= 7.2, the `pcntl` extension, and `messenger:consume --keepalive`.
 

--- a/src/Transport/AmqpReceiver.php
+++ b/src/Transport/AmqpReceiver.php
@@ -34,13 +34,7 @@ class AmqpReceiver implements QueueReceiverInterface, MessageCountAwareInterface
     #[Override]
     public function get(int|null $fetchSize = null): iterable
     {
-        if ($fetchSize !== null) {
-            yield from $this->getFromQueues($this->connection->getQueueNames(), max(1, $fetchSize));
-
-            return;
-        }
-
-        yield from $this->getFromQueues($this->connection->getQueueNames());
+        yield from $this->getFromQueues($this->connection->getQueueNames(), $fetchSize);
     }
 
     /**
@@ -53,24 +47,29 @@ class AmqpReceiver implements QueueReceiverInterface, MessageCountAwareInterface
     #[Override]
     public function getFromQueues(array $queueNames, int|null $fetchSize = null): iterable
     {
-        $remaining = $fetchSize !== null ? max(1, $fetchSize) : null;
+        // Symfony 8.1+ Worker always passes $fetchSize (--fetch-size). Config is
+        // only the default when that argument is omitted (Symfony < 8.1).
+        $fetchSize ??= $this->connection->getConfig()->fetchSize;
 
-        if ($remaining !== null) {
+        if ($fetchSize === null) {
             foreach ($queueNames as $queueName) {
-                foreach ($this->getEnvelopes($queueName, $fetchSize) as $envelope) {
-                    yield $envelope;
-
-                    if (--$remaining <= 0) {
-                        return;
-                    }
-                }
+                yield from $this->getEnvelopes($queueName);
             }
 
             return;
         }
 
+        $fetchSize = max(1, $fetchSize);
+        $remaining = $fetchSize;
+
         foreach ($queueNames as $queueName) {
-            yield from $this->getEnvelopes($queueName);
+            foreach ($this->getEnvelopes($queueName, $fetchSize) as $envelope) {
+                yield $envelope;
+
+                if (--$remaining <= 0) {
+                    return;
+                }
+            }
         }
     }
 

--- a/src/Transport/Config/ConnectionConfig.php
+++ b/src/Transport/Config/ConnectionConfig.php
@@ -40,6 +40,7 @@ readonly class ConnectionConfig
         'keepalive',
         'keepalive_enabled',
         'prefetch_count',
+        'fetch_size',
         'wait_timeout',
         'confirm_enabled',
         'confirm_timeout',
@@ -135,9 +136,15 @@ readonly class ConnectionConfig
         DelayConfig|null $delay = null,
         array|null $queues = null,
         string|null $connectionName = null,
+        // Default for get() when $fetchSize is omitted; ignored when the Worker passes one.
+        public int|null $fetchSize = null,
     ) {
         if ($waitTimeout === 0 || $waitTimeout === 0.0) {
             throw new InvalidArgumentException('Connection wait timeout cannot be zero. This will cause the consumer to wait forever and block the messenger worker loop.');
+        }
+
+        if ($fetchSize !== null && $fetchSize < 1) {
+            throw new InvalidArgumentException('Connection fetch size must be greater than zero. This limits how many messages get() yields before returning control to the messenger worker loop.');
         }
 
         if ($transactionsEnabled && $confirmEnabled) {
@@ -191,6 +198,7 @@ readonly class ConnectionConfig
      *     keepalive?: bool|mixed,
      *     keepalive_enabled?: bool|mixed,
      *     prefetch_count?: int|mixed,
+     *     fetch_size?: int|mixed,
      *     wait_timeout?: int|float|mixed,
      *     confirm_enabled?: bool|mixed,
      *     confirm_timeout?: int|float|mixed,
@@ -314,6 +322,7 @@ readonly class ConnectionConfig
             keepalive: ConfigHelper::getBool($connectionConfig, 'keepalive'),
             keepaliveEnabled: ConfigHelper::getBool($connectionConfig, 'keepalive_enabled'),
             prefetchCount: $prefetchCount,
+            fetchSize: ConfigHelper::getInt($connectionConfig, 'fetch_size'),
             waitTimeout: $waitTimeout,
             confirmEnabled: ConfigHelper::getBool($connectionConfig, 'confirm_enabled'),
             confirmTimeout: ConfigHelper::getFloat($connectionConfig, 'confirm_timeout'),

--- a/src/Transport/DsnParser.php
+++ b/src/Transport/DsnParser.php
@@ -71,6 +71,7 @@ class DsnParser
          *     keepalive?: bool|mixed,
          *     keepalive_enabled?: bool|mixed,
          *     prefetch_count?: int|mixed,
+         *     fetch_size?: int|mixed,
          *     wait_timeout?: int|float|mixed,
          *     confirm_enabled?: bool|mixed,
          *     confirm_timeout?: int|float|mixed,

--- a/tests/TestKernel.php
+++ b/tests/TestKernel.php
@@ -96,6 +96,7 @@ class TestKernel extends Kernel implements CompilerPassInterface
                             'options' => [
                                 'transactions_enabled' => false,
                                 'confirm_enabled' => true,
+                                'fetch_size' => 2,
                                 'wait_timeout' => 0.10, // lower wait_timeout for tests
                                 'exchange' => ['name' => 'test_fetch_size_exchange'],
                                 'queues' => [

--- a/tests/Transport/AmqpReceiverTest.php
+++ b/tests/Transport/AmqpReceiverTest.php
@@ -152,6 +152,103 @@ class AmqpReceiverTest extends TestCase
         self::assertCount(3, $this->envelopesToList($receiver->getFromQueues(['queue_name'])));
     }
 
+    public function testGetUsesConfiguredFetchSizeWhenArgumentOmitted(): void
+    {
+        $this->connectionConfig = new ConnectionConfig(fetchSize: 2);
+
+        $message      = new stdClass();
+        $envelope     = new Envelope($message);
+        $amqpMessage1 = new AMQPMessage(serialize($message), ['message_id' => '1']);
+        $amqpMessage2 = new AMQPMessage(serialize($message), ['message_id' => '2']);
+        $amqpMessage3 = new AMQPMessage(serialize($message), ['message_id' => '3']);
+
+        $connection = $this->getTestConnection();
+        $connection->method('getQueueNames')
+            ->willReturn(['queue_name']);
+
+        $connection->expects(self::once())
+            ->method('consume')
+            ->with('queue_name', 2)
+            ->willReturn([
+                new AmqpEnvelope($amqpMessage1),
+                new AmqpEnvelope($amqpMessage2),
+                new AmqpEnvelope($amqpMessage3),
+            ]);
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects(self::exactly(2))
+            ->method('decode')
+            ->willReturn($envelope);
+
+        $receiver = new AmqpReceiver($connection, $serializer);
+
+        self::assertCount(2, $this->envelopesToList($receiver->get()));
+    }
+
+    public function testGetFromQueuesUsesConfiguredFetchSizeWhenArgumentOmitted(): void
+    {
+        $this->connectionConfig = new ConnectionConfig(fetchSize: 2);
+
+        $message      = new stdClass();
+        $envelope     = new Envelope($message);
+        $amqpMessage1 = new AMQPMessage(serialize($message), ['message_id' => '1']);
+        $amqpMessage2 = new AMQPMessage(serialize($message), ['message_id' => '2']);
+        $amqpMessage3 = new AMQPMessage(serialize($message), ['message_id' => '3']);
+
+        $connection = $this->getTestConnection();
+
+        $connection->expects(self::once())
+            ->method('consume')
+            ->with('queue_name', 2)
+            ->willReturn([
+                new AmqpEnvelope($amqpMessage1),
+                new AmqpEnvelope($amqpMessage2),
+                new AmqpEnvelope($amqpMessage3),
+            ]);
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects(self::exactly(2))
+            ->method('decode')
+            ->willReturn($envelope);
+
+        $receiver = new AmqpReceiver($connection, $serializer);
+
+        self::assertCount(2, $this->envelopesToList($receiver->getFromQueues(['queue_name'])));
+    }
+
+    public function testExplicitFetchSizeOverridesConfiguredFetchSize(): void
+    {
+        $this->connectionConfig = new ConnectionConfig(fetchSize: 2);
+
+        $message      = new stdClass();
+        $envelope     = new Envelope($message);
+        $amqpMessage1 = new AMQPMessage(serialize($message), ['message_id' => '1']);
+        $amqpMessage2 = new AMQPMessage(serialize($message), ['message_id' => '2']);
+        $amqpMessage3 = new AMQPMessage(serialize($message), ['message_id' => '3']);
+
+        $connection = $this->getTestConnection();
+        $connection->method('getQueueNames')
+            ->willReturn(['queue_name']);
+
+        $connection->expects(self::once())
+            ->method('consume')
+            ->with('queue_name', 3)
+            ->willReturn([
+                new AmqpEnvelope($amqpMessage1),
+                new AmqpEnvelope($amqpMessage2),
+                new AmqpEnvelope($amqpMessage3),
+            ]);
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects(self::exactly(3))
+            ->method('decode')
+            ->willReturn($envelope);
+
+        $receiver = new AmqpReceiver($connection, $serializer);
+
+        self::assertCount(3, $this->envelopesToList($receiver->get(3)));
+    }
+
     public function testGetAcceptsFetchSize(): void
     {
         $message       = new stdClass();

--- a/tests/Transport/Config/ConnectionConfigTest.php
+++ b/tests/Transport/Config/ConnectionConfigTest.php
@@ -78,6 +78,7 @@ class ConnectionConfigTest extends TestCase
             'keepalive' => false,
             'keepalive_enabled' => true,
             'prefetch_count' => 15,
+            'fetch_size' => 10,
             'wait_timeout' => 2.0,
             'confirm_enabled' => true,
             'confirm_timeout' => 10.0,
@@ -124,6 +125,7 @@ class ConnectionConfigTest extends TestCase
         self::assertFalse($connectionConfig->keepalive);
         self::assertTrue($connectionConfig->keepaliveEnabled);
         self::assertSame(15, $connectionConfig->prefetchCount);
+        self::assertSame(10, $connectionConfig->fetchSize);
         self::assertSame(2.0, $connectionConfig->waitTimeout);
         self::assertTrue($connectionConfig->confirmEnabled);
         self::assertSame(10.0, $connectionConfig->confirmTimeout);
@@ -298,6 +300,24 @@ class ConnectionConfigTest extends TestCase
         new ConnectionConfig(waitTimeout: $waitTimeout);
     }
 
+    #[TestWith([0])]
+    #[TestWith([-1])]
+    public function testFetchSizeMustBeGreaterThanZero(int $fetchSize): void
+    {
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage('Connection fetch size must be greater than zero. This limits how many messages get() yields before returning control to the messenger worker loop.');
+
+        new ConnectionConfig(fetchSize: $fetchSize);
+    }
+
+    public function testFromArrayFetchSizeMustBeGreaterThanZero(): void
+    {
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage('Connection fetch size must be greater than zero. This limits how many messages get() yields before returning control to the messenger worker loop.');
+
+        ConnectionConfig::fromArray(['fetch_size' => 0]);
+    }
+
     public function testTransactionsAndConfirmsCannotBeEnabledAtTheSameTime(): void
     {
         self::expectException(InvalidArgumentException::class);
@@ -350,6 +370,7 @@ class ConnectionConfigTest extends TestCase
         self::assertTrue($connectionConfig->keepalive);
         self::assertFalse($connectionConfig->keepaliveEnabled);
         self::assertSame(1, $connectionConfig->prefetchCount);
+        self::assertNull($connectionConfig->fetchSize);
         self::assertSame(1, $connectionConfig->waitTimeout);
         self::assertTrue($connectionConfig->confirmEnabled);
         self::assertSame(3, $connectionConfig->confirmTimeout);

--- a/tests/Transport/DsnParserTest.php
+++ b/tests/Transport/DsnParserTest.php
@@ -180,6 +180,21 @@ class DsnParserTest extends TestCase
         self::assertFalse($connectionConfig->keepaliveEnabled);
     }
 
+    public function testFetchSize(): void
+    {
+        $connectionConfig = $this->dsnParser->parseDsn('phpamqplib://127.0.0.1');
+
+        self::assertNull($connectionConfig->fetchSize);
+
+        $connectionConfig = $this->dsnParser->parseDsn('phpamqplib://127.0.0.1?fetch_size=10');
+
+        self::assertSame(10, $connectionConfig->fetchSize);
+
+        $connectionConfig = $this->dsnParser->parseDsn('phpamqplib://127.0.0.1', ['fetch_size' => 5]);
+
+        self::assertSame(5, $connectionConfig->fetchSize);
+    }
+
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/TransportFunctionalTest.php
+++ b/tests/TransportFunctionalTest.php
@@ -324,6 +324,21 @@ class TransportFunctionalTest extends KernelTestCase
         }
     }
 
+    public function testConfiguredFetchSizeLimitsGetWithoutArgument(): void
+    {
+        for ($i = 1; $i <= 5; $i++) {
+            $this->fetchSizeTransport->send(Envelope::wrap(new ConfirmMessage($i)));
+        }
+
+        $this->fetchSizeTransport->getConnection()->reconnect();
+
+        $batch = $this->collectBatch($this->fetchSizeTransport, null);
+
+        self::assertCount(2, $batch);
+        self::assertSame(1, $batch[0]->getMessage()->count);
+        self::assertSame(2, $batch[1]->getMessage()->count);
+    }
+
     public function testFetchSizeLimitsAcrossMultipleQueues(): void
     {
         $this->multipleQueuesTransport->send(
@@ -890,12 +905,12 @@ class TransportFunctionalTest extends KernelTestCase
     }
 
     /** @return array<Envelope> */
-    private function collectBatch(AmqpTransport $transport, int $fetchSize): array
+    private function collectBatch(AmqpTransport $transport, int|null $fetchSize): array
     {
         $batch = [];
 
         /** @var Traversable<Envelope> $envelopes */
-        $envelopes = $transport->get($fetchSize);
+        $envelopes = $fetchSize !== null ? $transport->get($fetchSize) : $transport->get();
 
         foreach ($envelopes as $envelope) {
             $batch[] = $envelope;


### PR DESCRIPTION
## Summary
- Add an opt-in `fetch_size` DSN/yaml option used only when `get()` / `getFromQueues()` is called with no size (Symfony < 8.1 Worker).
- This is the same envelope cap as `messenger:consume --fetch-size`, not AMQP QoS (`prefetch_count`). Symfony 8.1+ always passes `--fetch-size`, so transport config is ignored there.
- Lets a busy `basic_consume` loop return to the Worker so other transports, `--time-limit`, and `messenger:stop-workers` can run ([#94](https://github.com/jwage/phpamqplib-messenger/issues/94)).

## Test plan
- [x] Unit: config/DSN parse, `get()` without args honors `fetch_size`, explicit `get(n)` wins
- [x] Functional: `fetch_size: 2` yields two envelopes when `get()` is called with no argument
- [x] Confirm Symfony 8.1 `messenger:consume --fetch-size` still takes precedence over yaml


Made with [Cursor](https://cursor.com)