### PR TITLE
Allow transport retries to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ In summary, `php-amqplib` provides a more robust and flexible solution for conne
 
 ## Message Reliability
 
-This bundle prioritizes message reliability over raw performance and implements **at-least-once**, not exactly-once, publishing semantics. Publisher confirms are enabled by default. After a retryable connection or channel failure, the transport either retries messages it still owns or throws so the caller can retry; it does not turn an uncertain publish into silent success. If RabbitMQ accepted a publish before the connection failed, recovery may publish that message twice, so handlers must be idempotent.
+This bundle prioritizes message reliability over raw performance and implements **at-least-once**, not exactly-once, publishing semantics. Publisher confirms are enabled by default. After a retryable connection or channel failure, the transport either retries messages it still owns or throws so the caller can retry; it does not turn an uncertain publish into silent success. If RabbitMQ accepted a publish before the connection failed, recovery may publish that message twice, so handlers must be idempotent. Retries can be turned off with `retries_enabled: false` if you cannot make handlers idempotent and accept possible message loss on a failed publish.
 
 For batched publishing, a live publisher-confirm timeout re-waits on the same channel instead of republishing. Batches remain in memory until `flush()` succeeds, including across reconnect and `Connection::close()`, but they are not durable across process termination. Always call `flush()` explicitly and propagate failures.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -144,6 +144,14 @@ framework:
                     # confirm_enabled and transactions_enabled cannot both be true.
                     transactions_enabled: false
 
+                    # Retry retryable connection and channel failures (closed
+                    # connection, I/O errors, timeouts). Enabled by default so a
+                    # publish is less likely to be lost. Recovery can deliver a
+                    # message more than once, so handlers must be idempotent.
+                    # Disable only if you cannot make handlers idempotent and
+                    # accept possible loss when a connection fails during publish.
+                    retries_enabled: true
+
                     # Connection name (optional for easier identification in server logs and management UI)
                     connection_name: ''
 
@@ -216,11 +224,14 @@ Any option can be specified in the DSN as an alternative to defining it in the `
 phpamqplib://guest:guest@localhost?heartbeat=60&read_timeout=5.0
 phpamqplib://guest:guest@localhost?heartbeat=10&keepalive_enabled=true
 phpamqplib://guest:guest@localhost?fetch_size=10
+phpamqplib://guest:guest@localhost?retries_enabled=false
 ```
 
 `fetch_size` on the DSN is the transport default described above, not `messenger:consume --fetch-size`.
 
 `keepalive_enabled=true` has no effect unless `heartbeat` is greater than 0. It also requires Symfony >= 7.2, the `pcntl` extension, and `messenger:consume --keepalive`.
+
+`retries_enabled=false` disables transport retries of retryable connection and channel failures. See [Delivery Reliability](#delivery-reliability).
 
 ## AmqpStamp
 
@@ -261,6 +272,8 @@ $bus->dispatch($envelope);
 ## Delivery Reliability
 
 The transport implements **at-least-once**, not exactly-once, publishing semantics. Publisher confirms are enabled by default, messages are persistent, and exchanges and queues are durable by default. After a retryable connection or channel failure, the transport either retries messages it still owns or throws so the caller can retry. If RabbitMQ accepted a publish before the connection failed, recovery may publish that message twice, so handlers must be idempotent.
+
+Retries are enabled by default (`retries_enabled: true`). Disable them only if you cannot make handlers idempotent and accept that a connection failure during publish may lose the message.
 
 Publisher confirms and transactions are mutually exclusive. If both are disabled, a successful socket write cannot prove durable broker acceptance. End-to-end durability also depends on keeping messages persistent, topology durable, and RabbitMQ configured for the durability guarantees your application requires.
 

--- a/src/Transport/Config/ConnectionConfig.php
+++ b/src/Transport/Config/ConnectionConfig.php
@@ -45,6 +45,7 @@ readonly class ConnectionConfig
         'confirm_enabled',
         'confirm_timeout',
         'transactions_enabled',
+        'retries_enabled',
         'ssl',
         'exchange',
         'delay',
@@ -94,6 +95,8 @@ readonly class ConnectionConfig
 
     public bool $transactionsEnabled;
 
+    public bool $retriesEnabled;
+
     public ExchangeConfig $exchange;
 
     public DelayConfig $delay;
@@ -131,6 +134,7 @@ readonly class ConnectionConfig
         bool|null $confirmEnabled = null,
         int|float|null $confirmTimeout = null,
         bool|null $transactionsEnabled = null,
+        bool|null $retriesEnabled = null,
         public SslConfig|null $ssl = null,
         ExchangeConfig|null $exchange = null,
         DelayConfig|null $delay = null,
@@ -172,6 +176,7 @@ readonly class ConnectionConfig
         $this->confirmEnabled      = $confirmEnabled ?? true;
         $this->confirmTimeout      = $confirmTimeout ?? self::DEFAULT_CONFIRM_TIMEOUT;
         $this->transactionsEnabled = $transactionsEnabled ?? false;
+        $this->retriesEnabled      = $retriesEnabled ?? true;
         $this->exchange            = $exchange ?? new ExchangeConfig();
         $this->delay               = $delay ?? new DelayConfig();
         $this->queues              = self::indexByQueueName($queues ?? []);
@@ -203,6 +208,7 @@ readonly class ConnectionConfig
      *     confirm_enabled?: bool|mixed,
      *     confirm_timeout?: int|float|mixed,
      *     transactions_enabled?: bool|mixed,
+     *     retries_enabled?: bool|mixed,
      *     ssl?: array{
      *         cafile?: string|null,
      *         capath?: string|null,
@@ -327,6 +333,7 @@ readonly class ConnectionConfig
             confirmEnabled: ConfigHelper::getBool($connectionConfig, 'confirm_enabled'),
             confirmTimeout: ConfigHelper::getFloat($connectionConfig, 'confirm_timeout'),
             transactionsEnabled: ConfigHelper::getBool($connectionConfig, 'transactions_enabled'),
+            retriesEnabled: ConfigHelper::getBool($connectionConfig, 'retries_enabled'),
             ssl: isset($connectionConfig['ssl']) ? SslConfig::fromArray($connectionConfig['ssl']) : null,
             exchange: isset($connectionConfig['exchange']) ? ExchangeConfig::fromArray($connectionConfig['exchange']) : null,
             delay: isset($connectionConfig['delay']) ? DelayConfig::fromArray($connectionConfig['delay']) : null,

--- a/src/Transport/Connection.php
+++ b/src/Transport/Connection.php
@@ -490,7 +490,7 @@ class Connection
     ): Retry {
         return $this->retryFactory->retry(
             $run,
-            $retries,
+            $this->resolveRetries($retries),
             $waitTime,
             $jitter,
         )
@@ -512,7 +512,7 @@ class Connection
     ): Retry {
         return $this->retryFactory->retry(
             $run,
-            $retries,
+            $this->resolveRetries($retries),
             $waitTime,
             $jitter,
         );
@@ -537,7 +537,7 @@ class Connection
     ): Retry {
         return $this->retryFactory->retry(
             $run,
-            $retries,
+            $this->resolveRetries($retries),
             $waitTime,
             $jitter,
         )
@@ -546,6 +546,20 @@ class Connection
                     $this->reconnect();
                 }
             });
+    }
+
+    /** Uses the configured retry budget unless the caller passed an explicit count. */
+    private function resolveRetries(int|null $retries): int|null
+    {
+        if ($retries !== null) {
+            return $retries;
+        }
+
+        if (! $this->connectionConfig->retriesEnabled) {
+            return 0;
+        }
+
+        return null;
     }
 
     /** Drops a failed publisher channel without disturbing a consumer on this connection. */

--- a/src/Transport/DsnParser.php
+++ b/src/Transport/DsnParser.php
@@ -75,6 +75,7 @@ class DsnParser
          *     wait_timeout?: int|float|mixed,
          *     confirm_enabled?: bool|mixed,
          *     confirm_timeout?: int|float|mixed,
+         *     retries_enabled?: bool|mixed,
          *     ssl: array{
          *         cafile?: string,
          *         capath?: string,

--- a/tests/Transport/Config/ConnectionConfigTest.php
+++ b/tests/Transport/Config/ConnectionConfigTest.php
@@ -82,6 +82,7 @@ class ConnectionConfigTest extends TestCase
             'wait_timeout' => 2.0,
             'confirm_enabled' => true,
             'confirm_timeout' => 10.0,
+            'retries_enabled' => false,
             'exchange' => [
                 'name' => 'custom_exchange',
                 'type' => 'fanout',
@@ -129,6 +130,7 @@ class ConnectionConfigTest extends TestCase
         self::assertSame(2.0, $connectionConfig->waitTimeout);
         self::assertTrue($connectionConfig->confirmEnabled);
         self::assertSame(10.0, $connectionConfig->confirmTimeout);
+        self::assertFalse($connectionConfig->retriesEnabled);
         self::assertSame('My test connection', $connectionConfig->connectionName);
 
         self::assertEquals(new ExchangeConfig(
@@ -374,6 +376,7 @@ class ConnectionConfigTest extends TestCase
         self::assertSame(1, $connectionConfig->waitTimeout);
         self::assertTrue($connectionConfig->confirmEnabled);
         self::assertSame(3, $connectionConfig->confirmTimeout);
+        self::assertTrue($connectionConfig->retriesEnabled);
         self::assertEquals(new ExchangeConfig(), $connectionConfig->exchange);
         self::assertEquals(new DelayConfig(), $connectionConfig->delay);
         self::assertSame([], $connectionConfig->queues);

--- a/tests/Transport/ConnectionTest.php
+++ b/tests/Transport/ConnectionTest.php
@@ -1703,6 +1703,49 @@ class ConnectionTest extends TestCase
         }
     }
 
+    public function testDirectPublishDoesNotRetryWhenRetriesAreDisabled(): void
+    {
+        $connectionConfig = new ConnectionConfig(
+            autoSetup: false,
+            confirmEnabled: true,
+            retriesEnabled: false,
+            exchange: new ExchangeConfig(name: 'exchange_name'),
+        );
+
+        $factory        = $this->createStub(AmqpConnectionFactory::class);
+        $amqpConnection = $this->createMock(AMQPStreamConnection::class);
+        $amqpChannel    = $this->createMock(AMQPChannel::class);
+
+        $factory->method('create')->willReturn($amqpConnection);
+        $amqpConnection->method('isConnected')->willReturn(true);
+        $amqpConnection->expects(self::once())
+            ->method('channel')
+            ->willReturn($amqpChannel);
+        $amqpConnection->expects(self::never())
+            ->method('reconnect');
+
+        $amqpChannel->method('confirm_select');
+        $amqpChannel->expects(self::once())
+            ->method('basic_publish')
+            ->willThrowException(new AMQPConnectionClosedException('Broken pipe or closed connection'));
+        $amqpChannel->expects(self::never())
+            ->method('wait_for_pending_acks');
+
+        $connection = new Connection(
+            retryFactory: new RetryFactory(),
+            amqpConnectionFactory: $factory,
+            connectionConfig: $connectionConfig,
+        );
+
+        try {
+            $connection->publish(body: 'lost on failure');
+            self::fail('Expected the publish to fail without retrying.');
+        } catch (TransportException $exception) {
+            self::assertSame('Broken pipe or closed connection', $exception->getMessage());
+            self::assertInstanceOf(AMQPConnectionClosedException::class, $exception->getPrevious());
+        }
+    }
+
     public function testDirectPublishRetriesWhenTheChannelCloses(): void
     {
         $this->assertDirectPublishRetriesRecoverableFailure(
@@ -2835,6 +2878,53 @@ class ConnectionTest extends TestCase
         }
     }
 
+    public function testFlushDoesNotRetryWhenRetriesAreDisabled(): void
+    {
+        $connectionConfig = new ConnectionConfig(
+            autoSetup: false,
+            confirmEnabled: false,
+            retriesEnabled: false,
+            exchange: new ExchangeConfig(name: 'exchange_name'),
+            queues: [
+                'queue_name' => new QueueConfig(name: 'queue_name'),
+            ],
+        );
+
+        $factory        = $this->createStub(AmqpConnectionFactory::class);
+        $amqpConnection = $this->createStub(AMQPStreamConnection::class);
+        $amqpChannel    = $this->createMock(AMQPChannel::class);
+
+        $factory->method('create')->willReturn($amqpConnection);
+        $amqpConnection->method('isConnected')->willReturn(true);
+        $amqpConnection->method('channel')->willReturn($amqpChannel);
+
+        $amqpChannel->expects(self::once())
+            ->method('batch_basic_publish');
+        $amqpChannel->expects(self::once())
+            ->method('publish_batch')
+            ->willThrowException(new AMQPConnectionClosedException('Broken pipe or closed connection'));
+
+        $connection = new Connection(
+            retryFactory: new RetryFactory(),
+            amqpConnectionFactory: $factory,
+            connectionConfig: $connectionConfig,
+        );
+
+        $connection->publish(body: 'retained body', batchSize: 2);
+
+        try {
+            $connection->flush();
+            self::fail('Expected the flush to fail without retrying.');
+        } catch (TransportException $exception) {
+            self::assertSame('Broken pipe or closed connection', $exception->getMessage());
+        }
+
+        $pendingBatchMessages = $this->getPendingBatchMessages($connection);
+
+        self::assertCount(1, $pendingBatchMessages);
+        self::assertSame('retained body', $pendingBatchMessages[0][0]->getBody());
+    }
+
     public function testFlushAfterExhaustedRetriesDoesNotDuplicateBatchOnLaterFlush(): void
     {
         $connectionConfig = new ConnectionConfig(
@@ -3298,6 +3388,46 @@ class ConnectionTest extends TestCase
         $this->connection->retry(static function (): void {
             throw new AMQPConnectionClosedException('test');
         }, waitTime: 0)->run();
+    }
+
+    public function testRetryDoesNotRetryWhenRetriesAreDisabled(): void
+    {
+        $connection = $this->createConnectionWithStubs(new ConnectionConfig(retriesEnabled: false));
+        $count      = 0;
+
+        try {
+            $connection->retry(static function () use (&$count): void {
+                $count++;
+
+                throw new AMQPConnectionClosedException('test');
+            }, waitTime: 0)->run();
+
+            self::fail('Expected the operation to fail without retrying.');
+        } catch (TransportException $exception) {
+            self::assertSame('test', $exception->getMessage());
+        }
+
+        self::assertSame(1, $count);
+    }
+
+    public function testRetryWithReconnectDoesNotRetryWhenRetriesAreDisabled(): void
+    {
+        $connection = $this->createConnectionWithStubs(new ConnectionConfig(retriesEnabled: false));
+        $count      = 0;
+
+        try {
+            $connection->retryWithReconnect(static function () use (&$count): void {
+                $count++;
+
+                throw new AMQPConnectionClosedException('test');
+            }, waitTime: 0)->run();
+
+            self::fail('Expected the operation to fail without retrying.');
+        } catch (TransportException $exception) {
+            self::assertSame('test', $exception->getMessage());
+        }
+
+        self::assertSame(1, $count);
     }
 
     public function testChannelInvalidatesCachedChannelWhenConnectionClosed(): void

--- a/tests/Transport/DsnParserTest.php
+++ b/tests/Transport/DsnParserTest.php
@@ -41,6 +41,7 @@ class DsnParserTest extends TestCase
         self::assertSame(0, $connectionConfig->heartbeat);
         self::assertSame(true, $connectionConfig->keepalive);
         self::assertSame(false, $connectionConfig->keepaliveEnabled);
+        self::assertSame(true, $connectionConfig->retriesEnabled);
         self::assertNull($connectionConfig->ssl);
         self::assertEquals(new ExchangeConfig(name: 'messages'), $connectionConfig->exchange);
         self::assertEquals(new DelayConfig(), $connectionConfig->delay);
@@ -180,6 +181,25 @@ class DsnParserTest extends TestCase
         self::assertFalse($connectionConfig->keepaliveEnabled);
     }
 
+    public function testRetriesEnabled(): void
+    {
+        $connectionConfig = $this->dsnParser->parseDsn('phpamqplib://127.0.0.1');
+
+        self::assertTrue($connectionConfig->retriesEnabled);
+
+        $connectionConfig = $this->dsnParser->parseDsn('phpamqplib://127.0.0.1?retries_enabled=false');
+
+        self::assertFalse($connectionConfig->retriesEnabled);
+
+        $connectionConfig = $this->dsnParser->parseDsn('phpamqplib://127.0.0.1', ['retries_enabled' => false]);
+
+        self::assertFalse($connectionConfig->retriesEnabled);
+
+        $connectionConfig = $this->dsnParser->parseDsn('phpamqplib://127.0.0.1', ['retries_enabled' => true]);
+
+        self::assertTrue($connectionConfig->retriesEnabled);
+    }
+
     public function testFetchSize(): void
     {
         $connectionConfig = $this->dsnParser->parseDsn('phpamqplib://127.0.0.1');
@@ -219,6 +239,7 @@ class DsnParserTest extends TestCase
         self::assertSame(5, $connectionConfig->heartbeat);
         self::assertSame(true, $connectionConfig->keepalive);
         self::assertSame('connection_name', $connectionConfig->connectionName);
+        self::assertFalse($connectionConfig->retriesEnabled);
 
         self::assertEquals(new SslConfig(
             cafile: 'cacert',
@@ -297,6 +318,7 @@ class DsnParserTest extends TestCase
             'rpc_timeout' => 4.0,
             'heartbeat' => 5,
             'keepalive' => true,
+            'retries_enabled' => false,
             'ssl' => ['cafile' => 'cacert'],
             'exchange' => [
                 'name' => 'exchange_name',


### PR DESCRIPTION
## Summary
- Adds a `retries_enabled` transport option (default `true`) so retryable connection and channel failures can be retried or failed immediately.
- Disabling retries avoids duplicate publishes from recovery when handlers cannot be made idempotent, at the cost of possible message loss if a publish fails.
- Documents the option and covers DSN, config, publish, flush, and retry-helper behavior in tests.

Closes #88

## Test plan
- [x] `ConnectionConfig` defaults to retries enabled and parses `retries_enabled: false`
- [x] DSN query and options accept `retries_enabled`
- [x] Direct publish, flush, `retry()`, and `retryWithReconnect()` fail on the first retryable error when disabled
- [x] CI phpcs, psalm, and PHPUnit pass


Made with [Cursor](https://cursor.com)