### PR TITLE
Document LavinMQ compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This bundle adds support for `php-amqplib/php-amqplib` to Symfony Messenger, providing an alternative way to connect to RabbitMQ using a pure PHP library instead of the [php-amqp](https://github.com/php-amqp/php-amqp) C extension.
 
+It is also compatible with [LavinMQ](https://lavinmq.com/), which speaks the same AMQP 0-9-1 protocol. CI and the local test broker run against RabbitMQ.
+
 ## Requirements
 
 - PHP 8.3, 8.4, or 8.5

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,8 @@
 
 This bundle adds support for `php-amqplib/php-amqplib` to Symfony Messenger, providing an alternative way to connect to RabbitMQ using a pure PHP library instead of the [php-amqp](https://github.com/php-amqp/php-amqp) C extension.
 
+It is also compatible with [LavinMQ](https://lavinmq.com/), which speaks the same AMQP 0-9-1 protocol. CI and the local test broker run against RabbitMQ.
+
 ## Requirements
 
 - PHP 8.3, 8.4, or 8.5


### PR DESCRIPTION
## Summary
- Document that the php-amqplib Messenger transport is compatible with [LavinMQ](https://lavinmq.com/) as well as RabbitMQ (same AMQP 0-9-1 protocol).
- Keep CI and the local test broker on RabbitMQ.

Closes #140

## Test plan
- [x] README and docs intros mention LavinMQ compatibility
- [x] Confirm `.github/workflows/ci.yml` and `docker-compose.yml` are unchanged and still use RabbitMQ


Made with [Cursor](https://cursor.com)