### PR TITLE
Add a no_ack consume option

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -140,6 +140,14 @@ framework:
                     # Prefetch settings (AMQP QoS: max unacked deliveries on the channel)
                     prefetch_count: 1
 
+                    # Auto-acknowledge deliveries on consume (AMQP no-ack). Off by
+                    # default so Messenger can ack or nack after handling. When
+                    # true, the broker treats a delivery as done immediately:
+                    # ack and reject become no-ops, a crash during handling can
+                    # lose the message, and failed handlers cannot requeue via
+                    # nack. Use only when that tradeoff is acceptable.
+                    no_ack: false
+
                     # Default for get() when the caller omits $fetchSize (Symfony < 8.1
                     # Worker). Same hint as messenger:consume --fetch-size. Omit for
                     # unlimited. Ignored when get($fetchSize) is passed, including
@@ -202,6 +210,7 @@ framework:
                         orders_messages:
                             prefetch_count: 5 # overrides the connection prefetch_count: 1
                             wait_timeout: 2.0 # overrides the connection wait_timeout: 1.0
+                            no_ack: true # overrides the connection no_ack: false
                             passive: false
                             durable: true
                             exclusive: false
@@ -243,11 +252,14 @@ Any option can be specified in the DSN as an alternative to defining it in the `
 phpamqplib://guest:guest@localhost?heartbeat=60&read_timeout=5.0
 phpamqplib://guest:guest@localhost?heartbeat=10&keepalive_enabled=true
 phpamqplib://guest:guest@localhost?fetch_size=10
+phpamqplib://guest:guest@localhost?no_ack=true
 phpamqplib://guest:guest@localhost?retries_enabled=false
 phpamqplib://guest:guest@localhost?retries=2&retry_wait_time=500
 ```
 
 `fetch_size` on the DSN is the transport default described above, not `messenger:consume --fetch-size`.
+
+`no_ack=true` auto-acknowledges deliveries. See [Delivery Reliability](#delivery-reliability).
 
 `keepalive_enabled=true` has no effect unless `heartbeat` is greater than 0. It also requires Symfony >= 7.2, the `pcntl` extension, and `messenger:consume --keepalive`.
 
@@ -294,6 +306,8 @@ $bus->dispatch($envelope);
 ## Delivery Reliability
 
 The transport implements **at-least-once**, not exactly-once, publishing semantics. Publisher confirms are enabled by default, messages are persistent, and exchanges and queues are durable by default. After a retryable connection or channel failure, the transport either retries messages it still owns or throws so the caller can retry. If RabbitMQ accepted a publish before the connection failed, recovery may publish that message twice, so handlers must be idempotent.
+
+Consume is also at-least-once unless `no_ack` is enabled. With the default (`no_ack: false`), the broker holds each delivery until Messenger acks or nacks it, so a crash during handling requeues the message. `no_ack: true` tells the broker to consider the message consumed on delivery. That avoids the ack round-trip and the `PRECONDITION_FAILED - unknown delivery tag` error that happens if you auto-ack but still send `basic.ack`. It also means a crash during handling can lose the message, failed handlers cannot requeue via nack, and AMQP prefetch has no effect because there are no unacked deliveries. Use a failure transport if you still need to record handler failures.
 
 Retries are enabled by default (`retries_enabled: true`) with 3 retries and a jittered wait of up to 1000ms between attempts. Disable them only if you cannot make handlers idempotent and accept that a connection failure during publish may lose the message. Raise `retries` or `retry_wait_time` when a longer recovery window is required.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -140,12 +140,10 @@ framework:
                     # Prefetch settings (AMQP QoS: max unacked deliveries on the channel)
                     prefetch_count: 1
 
-                    # Auto-acknowledge deliveries on consume (AMQP no-ack). Off by
-                    # default so Messenger can ack or nack after handling. When
-                    # true, the broker treats a delivery as done immediately:
-                    # ack and reject become no-ops, a crash during handling can
-                    # lose the message, and failed handlers cannot requeue via
-                    # nack. Use only when that tradeoff is acceptable.
+                    # Auto-acknowledge deliveries on consume (AMQP no-ack). Off
+                    # by default so the broker holds each delivery until
+                    # Messenger acks or nacks it. When true, the broker treats
+                    # a delivery as done immediately. See Delivery Reliability.
                     no_ack: false
 
                     # Default for get() when the caller omits $fetchSize (Symfony < 8.1
@@ -210,7 +208,7 @@ framework:
                         orders_messages:
                             prefetch_count: 5 # overrides the connection prefetch_count: 1
                             wait_timeout: 2.0 # overrides the connection wait_timeout: 1.0
-                            no_ack: true # overrides the connection no_ack: false
+                            no_ack: false # optional; queues inherit the connection value unless overridden
                             passive: false
                             durable: true
                             exclusive: false
@@ -307,7 +305,9 @@ $bus->dispatch($envelope);
 
 The transport implements **at-least-once**, not exactly-once, publishing semantics. Publisher confirms are enabled by default, messages are persistent, and exchanges and queues are durable by default. After a retryable connection or channel failure, the transport either retries messages it still owns or throws so the caller can retry. If RabbitMQ accepted a publish before the connection failed, recovery may publish that message twice, so handlers must be idempotent.
 
-Consume is also at-least-once unless `no_ack` is enabled. With the default (`no_ack: false`), the broker holds each delivery until Messenger acks or nacks it, so a crash during handling requeues the message. `no_ack: true` tells the broker to consider the message consumed on delivery. That avoids the ack round-trip and the `PRECONDITION_FAILED - unknown delivery tag` error that happens if you auto-ack but still send `basic.ack`. It also means a crash during handling can lose the message, failed handlers cannot requeue via nack, and AMQP prefetch has no effect because there are no unacked deliveries. Use a failure transport if you still need to record handler failures.
+Consume is also at-least-once unless `no_ack` is enabled. With the default (`no_ack: false`), the broker holds each delivery until Messenger acks or nacks it, so a crash during handling requeues the message. `no_ack: true` tells the broker to consider the message consumed on delivery. That avoids the ack round-trip and the `PRECONDITION_FAILED - unknown delivery tag` error that happens if you auto-ack but still send `basic.ack`.
+
+Messenger `retry_strategy` still works: it republishes a new envelope, then acks the original (a no-op). A failure transport still works: it copies the message, then rejects (also a no-op). Requeue via `basic.nack` does not, so a dead-letter exchange that depends on nack will not see handler or decode failures. A crash during handling can lose the message. AMQP `prefetch_count` has no effect because there are no unacked deliveries; the broker may push freely. `fetch_size` only limits how many envelopes the Worker yields, not how many the client has already been given.
 
 Retries are enabled by default (`retries_enabled: true`) with 3 retries and a jittered wait of up to 1000ms between attempts. Disable them only if you cannot make handlers idempotent and accept that a connection failure during publish may lose the message. Raise `retries` or `retry_wait_time` when a longer recovery window is required.
 

--- a/src/Transport/AmqpConsumer.php
+++ b/src/Transport/AmqpConsumer.php
@@ -242,6 +242,11 @@ class AmqpConsumer
     {
         $this->noAck = $queueConfig->noAck;
 
+        $this->debug->log('Registering AMQP consumer', [
+            'queue' => $queueConfig->name,
+            'no_ack' => $this->noAck,
+        ]);
+
         $this->consumerTag = $this->connection->consumerChannel()->basic_consume(
             queue: $queueConfig->name,
             consumer_tag: '',

--- a/src/Transport/AmqpConsumer.php
+++ b/src/Transport/AmqpConsumer.php
@@ -26,6 +26,8 @@ class AmqpConsumer
 
     private int|null $effectivePrefetchCount = null;
 
+    private bool $noAck = false;
+
     public function __construct(
         private Connection $connection,
         private ConnectionConfig $connectionConfig,
@@ -188,7 +190,7 @@ class AmqpConsumer
 
     public function callback(AMQPMessage $amqpMessage): void
     {
-        $this->buffer[] = new AmqpEnvelope($amqpMessage);
+        $this->buffer[] = new AmqpEnvelope($amqpMessage, noAck: $this->noAck);
     }
 
     public function hasBufferedEnvelopes(): bool
@@ -238,11 +240,13 @@ class AmqpConsumer
      */
     private function start(QueueConfig $queueConfig): void
     {
+        $this->noAck = $queueConfig->noAck;
+
         $this->consumerTag = $this->connection->consumerChannel()->basic_consume(
             queue: $queueConfig->name,
             consumer_tag: '',
             no_local: false,
-            no_ack: false,
+            no_ack: $this->noAck,
             exclusive: false,
             nowait: false,
             callback: $this->callback(...),

--- a/src/Transport/AmqpEnvelope.php
+++ b/src/Transport/AmqpEnvelope.php
@@ -16,6 +16,7 @@ class AmqpEnvelope
 {
     public function __construct(
         private AMQPMessage $amqpMessage,
+        private bool $noAck = false,
     ) {
     }
 
@@ -35,11 +36,19 @@ class AmqpEnvelope
 
     public function ack(): void
     {
+        if ($this->noAck) {
+            return;
+        }
+
         $this->amqpMessage->ack();
     }
 
     public function nack(): void
     {
+        if ($this->noAck) {
+            return;
+        }
+
         $this->amqpMessage->nack();
     }
 

--- a/src/Transport/Config/ConnectionConfig.php
+++ b/src/Transport/Config/ConnectionConfig.php
@@ -47,6 +47,7 @@ readonly class ConnectionConfig
         'prefetch_count',
         'fetch_size',
         'wait_timeout',
+        'no_ack',
         'confirm_enabled',
         'confirm_timeout',
         'transactions_enabled',
@@ -96,6 +97,8 @@ readonly class ConnectionConfig
 
     public int|float|null $waitTimeout;
 
+    public bool $noAck;
+
     public bool $confirmEnabled;
 
     public int|float $confirmTimeout;
@@ -144,6 +147,7 @@ readonly class ConnectionConfig
         bool|null $keepaliveEnabled = null,
         int|null $prefetchCount = null,
         int|float|null $waitTimeout = null,
+        bool|null $noAck = null,
         bool|null $confirmEnabled = null,
         int|float|null $confirmTimeout = null,
         bool|null $transactionsEnabled = null,
@@ -196,6 +200,7 @@ readonly class ConnectionConfig
         $this->keepaliveEnabled    = $keepaliveEnabled ?? false;
         $this->prefetchCount       = $prefetchCount ?? self::DEFAULT_PREFETCH_COUNT;
         $this->waitTimeout         = $waitTimeout ?? self::DEFAULT_WAIT_TIMEOUT;
+        $this->noAck               = $noAck ?? false;
         $this->confirmEnabled      = $confirmEnabled ?? true;
         $this->confirmTimeout      = $confirmTimeout ?? self::DEFAULT_CONFIRM_TIMEOUT;
         $this->transactionsEnabled = $transactionsEnabled ?? false;
@@ -230,6 +235,7 @@ readonly class ConnectionConfig
      *     prefetch_count?: int|mixed,
      *     fetch_size?: int|mixed,
      *     wait_timeout?: int|float|mixed,
+     *     no_ack?: bool|mixed,
      *     confirm_enabled?: bool|mixed,
      *     confirm_timeout?: int|float|mixed,
      *     transactions_enabled?: bool|mixed,
@@ -274,6 +280,7 @@ readonly class ConnectionConfig
      *         name?: string,
      *         prefetch_count?: int|mixed,
      *         wait_timeout?: int|float|mixed,
+     *         no_ack?: bool|mixed,
      *         passive?: bool|mixed,
      *         durable?: bool|mixed,
      *         exclusive?: bool|mixed,
@@ -295,12 +302,14 @@ readonly class ConnectionConfig
 
         $prefetchCount = ConfigHelper::getInt($connectionConfig, 'prefetch_count');
         $waitTimeout   = ConfigHelper::getFloat($connectionConfig, 'wait_timeout');
+        $noAck         = ConfigHelper::getBool($connectionConfig, 'no_ack');
 
         /**
          * @var array<int|string, array{
          *     name?: string,
          *     prefetch_count?: int|mixed,
          *     wait_timeout?: int|float|mixed,
+         *     no_ack?: bool|mixed,
          *     passive?: bool|mixed,
          *     durable?: bool|mixed,
          *     exclusive?: bool|mixed,
@@ -331,6 +340,10 @@ readonly class ConnectionConfig
                 $queue['wait_timeout'] = $waitTimeout;
             }
 
+            if ($noAck !== null && ! isset($queue['no_ack'])) {
+                $queue['no_ack'] = $noAck;
+            }
+
             $queueName = $queue['name'] ?? '';
 
             $queueConfigs[$queueName] = QueueConfig::fromArray($queue);
@@ -357,6 +370,7 @@ readonly class ConnectionConfig
             prefetchCount: $prefetchCount,
             fetchSize: ConfigHelper::getInt($connectionConfig, 'fetch_size'),
             waitTimeout: $waitTimeout,
+            noAck: $noAck,
             confirmEnabled: ConfigHelper::getBool($connectionConfig, 'confirm_enabled'),
             confirmTimeout: ConfigHelper::getFloat($connectionConfig, 'confirm_timeout'),
             transactionsEnabled: ConfigHelper::getBool($connectionConfig, 'transactions_enabled'),

--- a/src/Transport/Config/QueueConfig.php
+++ b/src/Transport/Config/QueueConfig.php
@@ -15,6 +15,7 @@ final readonly class QueueConfig
         'name',
         'prefetch_count',
         'wait_timeout',
+        'no_ack',
         'passive',
         'durable',
         'exclusive',
@@ -29,6 +30,8 @@ final readonly class QueueConfig
     public int $prefetchCount;
 
     public int|float|null $waitTimeout;
+
+    public bool $noAck;
 
     public bool $passive;
 
@@ -54,6 +57,7 @@ final readonly class QueueConfig
         string|null $name = null,
         int|null $prefetchCount = null,
         int|float|null $waitTimeout = null,
+        bool|null $noAck = null,
         bool|null $passive = null,
         bool|null $durable = null,
         bool|null $exclusive = null,
@@ -72,6 +76,7 @@ final readonly class QueueConfig
         $this->name          = $name;
         $this->prefetchCount = $prefetchCount ?? ConnectionConfig::DEFAULT_PREFETCH_COUNT;
         $this->waitTimeout   = $waitTimeout ?? ConnectionConfig::DEFAULT_WAIT_TIMEOUT;
+        $this->noAck         = $noAck ?? false;
         $this->passive       = $passive ?? false;
         $this->durable       = $durable ?? true;
         $this->exclusive     = $exclusive ?? false;
@@ -85,6 +90,7 @@ final readonly class QueueConfig
      *     name?: string,
      *     prefetch_count?: int|mixed,
      *     wait_timeout?: int|float|mixed,
+     *     no_ack?: bool|mixed,
      *     passive?: bool|mixed,
      *     durable?: bool|mixed,
      *     exclusive?: bool|mixed,
@@ -144,6 +150,7 @@ final readonly class QueueConfig
             name: ConfigHelper::getString($queueConfig, 'name'),
             prefetchCount: ConfigHelper::getInt($queueConfig, 'prefetch_count'),
             waitTimeout: ConfigHelper::getFloat($queueConfig, 'wait_timeout'),
+            noAck: ConfigHelper::getBool($queueConfig, 'no_ack'),
             passive: ConfigHelper::getBool($queueConfig, 'passive'),
             durable: ConfigHelper::getBool($queueConfig, 'durable'),
             exclusive: ConfigHelper::getBool($queueConfig, 'exclusive'),

--- a/src/Transport/DsnParser.php
+++ b/src/Transport/DsnParser.php
@@ -73,6 +73,7 @@ class DsnParser
          *     prefetch_count?: int|mixed,
          *     fetch_size?: int|mixed,
          *     wait_timeout?: int|float|mixed,
+         *     no_ack?: bool|mixed,
          *     confirm_enabled?: bool|mixed,
          *     confirm_timeout?: int|float|mixed,
          *     retries_enabled?: bool|mixed,

--- a/tests/E2e/E2eKernel.php
+++ b/tests/E2e/E2eKernel.php
@@ -51,6 +51,7 @@ class E2eKernel extends Kernel
                 'phpamqplib://guest:guest@127.0.0.1:5673/%2f/e2e_keepalive',
                 'phpamqplib://guest:guest@127.0.0.1:5673/%2f/e2e_ssl',
                 'phpamqplib://guest:guest@127.0.0.1:5673/%2f/e2e_auto',
+                'phpamqplib://guest:guest@127.0.0.1:5673/%2f/e2e_no_ack',
             ];
 
             $container->setParameter('env(MESSENGER_TRANSPORT_PHPAMQPLIB_DSN)', $defaults[0]);
@@ -64,6 +65,7 @@ class E2eKernel extends Kernel
             $container->setParameter('env(E2E_KEEPALIVE_DSN)', $defaults[8]);
             $container->setParameter('env(E2E_SSL_DSN)', $defaults[9]);
             $container->setParameter('env(E2E_AUTO_DSN)', $defaults[10]);
+            $container->setParameter('env(E2E_NO_ACK_DSN)', $defaults[11]);
             $container->setParameter('env(E2E_MULTI_EXCHANGE)', 'e2e_multi');
             $container->setParameter('env(E2E_ORDER_QUEUE)', 'e2e_order');
             $container->setParameter('env(E2E_QUOTE_QUEUE)', 'e2e_quote');
@@ -165,6 +167,7 @@ class E2eKernel extends Kernel
                             ],
                         ]),
                         'e2e_auto' => $amqp('%env(E2E_AUTO_DSN)%'),
+                        'e2e_no_ack' => $amqp('%env(E2E_NO_ACK_DSN)%', ['no_ack' => true]),
                         'e2e_memory' => 'in-memory://',
                     ],
                     'routing' => [
@@ -179,6 +182,7 @@ class E2eKernel extends Kernel
                         E2eMemoryMessage::class => 'e2e_memory',
                         E2eSslMessage::class => 'e2e_ssl',
                         E2eAutoMessage::class => 'e2e_auto',
+                        E2eNoAckMessage::class => 'e2e_no_ack',
                     ],
                 ],
             ]);
@@ -203,6 +207,7 @@ class E2eKernel extends Kernel
             $handler->addTag('messenger.message_handler', ['method' => 'handleMemory', 'handles' => E2eMemoryMessage::class]);
             $handler->addTag('messenger.message_handler', ['method' => 'handleSsl', 'handles' => E2eSslMessage::class]);
             $handler->addTag('messenger.message_handler', ['method' => 'handleAuto', 'handles' => E2eAutoMessage::class]);
+            $handler->addTag('messenger.message_handler', ['method' => 'handleNoAck', 'handles' => E2eNoAckMessage::class]);
 
             $container->register('logger', FileLogger::class)
                 ->setArgument('$file', '%env(E2E_DEBUG_LOG)%')

--- a/tests/E2e/E2eMessageHandler.php
+++ b/tests/E2e/E2eMessageHandler.php
@@ -75,6 +75,11 @@ class E2eMessageHandler
         // Handling is recorded by E2eConsumeEventSubscriber.
     }
 
+    public function handleNoAck(E2eNoAckMessage $_message): void
+    {
+        // Handling is recorded by E2eConsumeEventSubscriber.
+    }
+
     private function applySideEffects(E2eMessage $message): void
     {
         if ($message->failUntilAttempt > 0) {

--- a/tests/E2e/E2eNoAckMessage.php
+++ b/tests/E2e/E2eNoAckMessage.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jwage\PhpAmqpLibMessengerBundle\Tests\E2e;
+
+class E2eNoAckMessage
+{
+    public function __construct(
+        public string $id,
+    ) {
+    }
+}

--- a/tests/E2e/E2eTestCase.php
+++ b/tests/E2e/E2eTestCase.php
@@ -99,7 +99,7 @@ abstract class E2eTestCase extends TestCase
             'APP_ENV' => 'test',
             // kernel.debug so wait/consume traces land in E2E_DEBUG_LOG / TEST_LOG_DIR.
             'APP_DEBUG' => '1',
-            'E2E_CACHE' => 'e2e-v6',
+            'E2E_CACHE' => 'e2e-v7',
             'E2E_LOG' => $this->logFile,
             'E2E_DEBUG_LOG' => $this->debugLogFile,
             'TEST_LOG_DIR' => $testLogDir,
@@ -116,6 +116,7 @@ abstract class E2eTestCase extends TestCase
             'E2E_KEEPALIVE_DSN' => $this->dsnForExchange($prefix . '_keepalive'),
             'E2E_SSL_DSN' => $this->sslDsnForPrefix($prefix),
             'E2E_AUTO_DSN' => $this->dsnForExchange($prefix . '_auto'),
+            'E2E_NO_ACK_DSN' => $this->dsnForExchange($prefix . '_no_ack'),
             'SHELL_VERBOSITY' => '3',
         ];
 
@@ -168,6 +169,7 @@ abstract class E2eTestCase extends TestCase
                     'e2e_keepalive',
                     'e2e_ssl',
                     'e2e_auto',
+                    'e2e_no_ack',
                 ] as $transport
             ) {
                 $this->deleteTransportTopology($transport);

--- a/tests/E2e/MessengerConsumeE2eTest.php
+++ b/tests/E2e/MessengerConsumeE2eTest.php
@@ -299,4 +299,26 @@ class MessengerConsumeE2eTest extends E2eTestCase
         self::assertSame([$id], $handled);
         $this->assertQueueEventuallyEmpty('e2e_high');
     }
+
+    public function testNoAckConsumerAcksWithoutUnknownDeliveryTag(): void
+    {
+        $this->setupTransport('e2e_no_ack');
+
+        $ids = [
+            $this->uniqueId('no-ack-a'),
+            $this->uniqueId('no-ack-b'),
+        ];
+
+        $this->bus()->dispatch(new E2eNoAckMessage($ids[0]));
+        $this->bus()->dispatch(new E2eNoAckMessage($ids[1]));
+
+        $this->startConsume(['e2e_no_ack'], limit: 2);
+        $this->assertConsumeExitsSuccessfully();
+
+        $output = $this->lastProcess()->stdout() . $this->lastProcess()->stderr();
+        self::assertStringNotContainsString('PRECONDITION_FAILED', $output, $this->lastProcess()->debugOutput());
+        self::assertStringNotContainsString('unknown delivery tag', $output, $this->lastProcess()->debugOutput());
+        self::assertSame($ids, $this->idsOf($this->recordsOfType(E2eNoAckMessage::class)));
+        $this->assertQueueEventuallyEmpty('e2e_no_ack');
+    }
 }

--- a/tests/Functional/Transport/ConnectionLiveTest.php
+++ b/tests/Functional/Transport/ConnectionLiveTest.php
@@ -478,6 +478,80 @@ class ConnectionLiveTest extends TestCase
         }
     }
 
+    public function testNoAckAckAndNackDoNotCloseTheChannel(): void
+    {
+        $name       = $this->harness->topologyName('no_ack_ack');
+        $connection = $this->harness->connect($this->harness->topology(
+            $name,
+            ['wait_timeout' => 2],
+            ['no_ack' => true, 'wait_timeout' => 2],
+        ));
+
+        $connection->publish(body: 'auto-acked-one');
+        $first = $this->harness->consumeOne($connection, $name);
+        $first->ack();
+        $first->nack();
+
+        $connection->publish(body: 'auto-acked-two');
+        $second = $this->harness->consumeOne($connection, $name);
+        $second->ack();
+
+        self::assertSame(0, $connection->countMessagesInQueues());
+        $this->assertLoggerHasNoUnknownDeliveryTag();
+        self::assertSame(
+            [
+                'queue' => $name,
+                'no_ack' => true,
+            ],
+            $this->harness->logger()->contextFor('Registering AMQP consumer'),
+        );
+    }
+
+    public function testNoAckDeliveryIsNotRedeliveredAfterCloseWithoutAck(): void
+    {
+        $name       = $this->harness->topologyName('no_ack_close');
+        $connection = $this->harness->connect($this->harness->topology(
+            $name,
+            ['wait_timeout' => 2],
+            ['no_ack' => true, 'wait_timeout' => 2],
+        ));
+
+        $connection->publish(body: 'drop-on-delivery');
+        $this->harness->consumeOne($connection, $name);
+        $connection->close();
+
+        $again = $this->harness->connect($this->harness->topology(
+            $name,
+            ['wait_timeout' => 2],
+            ['no_ack' => true, 'wait_timeout' => 2],
+        ));
+
+        self::assertSame(0, $again->countMessagesInQueues());
+        $this->assertLoggerHasNoUnknownDeliveryTag();
+    }
+
+    public function testUnackedDeliveryIsRedeliveredAfterClose(): void
+    {
+        $name       = $this->harness->topologyName('ack_close');
+        $connection = $this->harness->connect($this->harness->topology(
+            $name,
+            ['wait_timeout' => 2],
+            ['wait_timeout' => 2],
+        ));
+
+        $connection->publish(body: 'hold-until-close');
+        $this->harness->consumeOne($connection, $name);
+        $connection->close();
+
+        $again = $this->harness->connect($this->harness->topology(
+            $name,
+            ['wait_timeout' => 2],
+            ['wait_timeout' => 2],
+        ));
+
+        self::assertSame(1, $again->countMessagesInQueues());
+    }
+
     public function testCloseKeepsWaitCoordinatorRegistrationOnALiveConnection(): void
     {
         $name       = $this->harness->topologyName('close_reg');
@@ -549,5 +623,13 @@ class ConnectionLiveTest extends TestCase
         ]));
 
         return [$name, $connection];
+    }
+
+    private function assertLoggerHasNoUnknownDeliveryTag(): void
+    {
+        foreach ($this->harness->logger()->records as $record) {
+            self::assertStringNotContainsString('PRECONDITION_FAILED', $record['message']);
+            self::assertStringNotContainsString('unknown delivery tag', $record['message']);
+        }
     }
 }

--- a/tests/Functional/TransportFunctionalTest.php
+++ b/tests/Functional/TransportFunctionalTest.php
@@ -49,6 +49,8 @@ class TransportFunctionalTest extends KernelTestCase
 
     private AmqpTransport $multipleQueuesTransport;
 
+    private AmqpTransport $noAckTransport;
+
     public function testTransportWithConfirms(): void
     {
         $envelopes = $this->getEnvelopes($this->confirmsTransport, 0);
@@ -845,6 +847,55 @@ class TransportFunctionalTest extends KernelTestCase
         self::assertSame('expired', $amqpEnvelope->getHeader('x-first-death-reason'));
     }
 
+    public function testNoAckAckDoesNotRaiseUnknownDeliveryTag(): void
+    {
+        $this->noAckTransport->send(Envelope::wrap(new ConfirmMessage(2101)));
+        $this->noAckTransport->send(Envelope::wrap(new ConfirmMessage(2102)));
+
+        $envelopes = $this->getEnvelopes($this->noAckTransport, 2);
+
+        self::assertSame(2101, $envelopes[0]->getMessage()->count);
+        self::assertSame(2102, $envelopes[1]->getMessage()->count);
+        self::assertSame(0, $this->noAckTransport->getMessageCount());
+    }
+
+    public function testNoAckRejectDoesNotRaiseUnknownDeliveryTag(): void
+    {
+        $this->noAckTransport->send(Envelope::wrap(new ConfirmMessage(2103)));
+
+        /** @var Traversable<Envelope> $receivedEnvelopes */
+        $receivedEnvelopes = $this->noAckTransport->get();
+
+        /** @var list<Envelope> $received */
+        $received = iterator_to_array($receivedEnvelopes, false);
+        self::assertCount(1, $received);
+        self::assertSame(2103, $received[0]->getMessage()->count);
+
+        $this->noAckTransport->reject($received[0]);
+        $this->noAckTransport->getConnection()->close();
+
+        self::assertSame(0, $this->noAckTransport->getMessageCount());
+        self::assertCount(0, iterator_to_array($this->noAckTransport->get(), false));
+    }
+
+    public function testNoAckDeliveryIsNotRedeliveredAfterCloseWithoutAck(): void
+    {
+        $this->noAckTransport->send(Envelope::wrap(new ConfirmMessage(2104)));
+
+        /** @var Traversable<Envelope> $receivedEnvelopes */
+        $receivedEnvelopes = $this->noAckTransport->get();
+
+        /** @var list<Envelope> $received */
+        $received = iterator_to_array($receivedEnvelopes, false);
+        self::assertCount(1, $received);
+        self::assertSame(2104, $received[0]->getMessage()->count);
+
+        $this->noAckTransport->getConnection()->close();
+
+        self::assertSame(0, $this->noAckTransport->getMessageCount());
+        self::assertCount(0, iterator_to_array($this->noAckTransport->get(), false));
+    }
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -878,14 +929,21 @@ class TransportFunctionalTest extends KernelTestCase
 
         $this->multipleQueuesTransport = $multipleQueuesTransport;
 
+        $noAckTransport = $container->get('messenger.transport.with_no_ack');
+        assert($noAckTransport instanceof AmqpTransport);
+
+        $this->noAckTransport = $noAckTransport;
+
         $this->confirmsTransport->setup();
         $this->transactionsTransport->setup();
         $this->fetchSizeTransport->setup();
         $this->multipleQueuesTransport->setup();
+        $this->noAckTransport->setup();
         $this->drainTransport($this->confirmsTransport);
         $this->drainTransport($this->transactionsTransport);
         $this->drainTransport($this->fetchSizeTransport);
         $this->drainTransport($this->multipleQueuesTransport);
+        $this->drainTransport($this->noAckTransport);
     }
 
     protected function tearDown(): void
@@ -894,6 +952,7 @@ class TransportFunctionalTest extends KernelTestCase
         $this->transactionsTransport->getConnection()->close();
         $this->fetchSizeTransport->getConnection()->close();
         $this->multipleQueuesTransport->getConnection()->close();
+        $this->noAckTransport->getConnection()->close();
 
         /** @psalm-suppress InternalMethod */
         TestLog::endTest(static::class . '::' . $this->name());

--- a/tests/Functional/TransportFunctionalTest.php
+++ b/tests/Functional/TransportFunctionalTest.php
@@ -875,7 +875,10 @@ class TransportFunctionalTest extends KernelTestCase
         $this->noAckTransport->getConnection()->close();
 
         self::assertSame(0, $this->noAckTransport->getMessageCount());
-        self::assertCount(0, iterator_to_array($this->noAckTransport->get(), false));
+
+        /** @var Traversable<Envelope> $afterReject */
+        $afterReject = $this->noAckTransport->get();
+        self::assertCount(0, iterator_to_array($afterReject, false));
     }
 
     public function testNoAckDeliveryIsNotRedeliveredAfterCloseWithoutAck(): void
@@ -893,7 +896,10 @@ class TransportFunctionalTest extends KernelTestCase
         $this->noAckTransport->getConnection()->close();
 
         self::assertSame(0, $this->noAckTransport->getMessageCount());
-        self::assertCount(0, iterator_to_array($this->noAckTransport->get(), false));
+
+        /** @var Traversable<Envelope> $afterClose */
+        $afterClose = $this->noAckTransport->get();
+        self::assertCount(0, iterator_to_array($afterClose, false));
     }
 
     protected function setUp(): void

--- a/tests/TestKernel.php
+++ b/tests/TestKernel.php
@@ -126,6 +126,19 @@ class TestKernel extends Kernel implements CompilerPassInterface
                                 ],
                             ],
                         ],
+                        'with_no_ack' => [
+                            'dsn' => '%env(MESSENGER_TRANSPORT_PHPAMQPLIB_DSN)%',
+                            'options' => [
+                                'transactions_enabled' => false,
+                                'confirm_enabled' => true,
+                                'no_ack' => true,
+                                'wait_timeout' => 0.10, // lower wait_timeout for tests
+                                'exchange' => ['name' => 'test_no_ack_exchange'],
+                                'queues' => [
+                                    'test_no_ack_queue' => [],
+                                ],
+                            ],
+                        ],
                     ],
                     'routing' => [
                         ConfirmMessage::class => 'with_confirms',

--- a/tests/Unit/Transport/AmqpConsumerTest.php
+++ b/tests/Unit/Transport/AmqpConsumerTest.php
@@ -1039,7 +1039,13 @@ class AmqpConsumerTest extends TestCase
         $connection->method('getQueueNames')
             ->willReturn(['test_queue']);
 
-        $consumer = $this->getTestConsumer(connectionConfig: $connectionConfig, connection: $connection);
+        $logger   = new CollectingLogger();
+        $consumer = $this->getTestConsumer(
+            connectionConfig: $connectionConfig,
+            connection: $connection,
+            logger: $logger,
+            debug: new Debug($logger, true),
+        );
 
         $channel->expects(self::once())
             ->method('basic_qos');
@@ -1068,6 +1074,14 @@ class AmqpConsumerTest extends TestCase
         /** @var Traversable<AmqpEnvelope> $started */
         $started = $consumer->consume('test_queue');
         iterator_to_array($started);
+
+        self::assertSame(
+            [
+                'queue' => 'test_queue',
+                'no_ack' => $noAck,
+            ],
+            $logger->contextFor('Registering AMQP consumer'),
+        );
 
         $message = $this->createMock(AMQPMessage::class);
         $message->expects($noAck ? self::never() : self::once())

--- a/tests/Unit/Transport/AmqpConsumerTest.php
+++ b/tests/Unit/Transport/AmqpConsumerTest.php
@@ -19,6 +19,7 @@ use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Exception\AMQPProtocolChannelException;
 use PhpAmqpLib\Exception\AMQPTimeoutException;
 use PhpAmqpLib\Message\AMQPMessage;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Stub;
 use Psr\Log\LoggerInterface;
@@ -1013,6 +1014,77 @@ class AmqpConsumerTest extends TestCase
         $amqpEnvelopes = $consumer->consume('test_queue');
 
         self::assertCount(0, iterator_to_array($amqpEnvelopes));
+    }
+
+    #[TestWith([false])]
+    #[TestWith([true])]
+    public function testConsumeRespectsNoAck(bool $noAck): void
+    {
+        $connectionConfig = new ConnectionConfig(
+            queues: [
+                'test_queue' => new QueueConfig(
+                    name: 'test_queue',
+                    prefetchCount: 20,
+                    waitTimeout: 2,
+                    noAck: $noAck,
+                ),
+            ],
+        );
+
+        $channel = $this->createMock(AMQPChannel::class);
+
+        $connection = $this->getTestConnectionStub(connectionConfig: $connectionConfig);
+        $connection->method('consumerChannel')
+            ->willReturn($channel);
+        $connection->method('getQueueNames')
+            ->willReturn(['test_queue']);
+
+        $consumer = $this->getTestConsumer(connectionConfig: $connectionConfig, connection: $connection);
+
+        $channel->expects(self::once())
+            ->method('basic_qos');
+
+        $channel->expects(self::once())
+            ->method('basic_consume')
+            ->with(
+                queue: 'test_queue',
+                consumer_tag: '',
+                no_local: false,
+                no_ack: $noAck,
+                exclusive: false,
+                nowait: false,
+                callback: self::isInstanceOf(Closure::class),
+            )
+            ->willReturn('consumer_tag');
+
+        $channel->expects(self::once())
+            ->method('is_consuming')
+            ->willReturn(true);
+
+        $channel->expects(self::once())
+            ->method('wait')
+            ->will($this->throwException(new AMQPTimeoutException()));
+
+        /** @var Traversable<AmqpEnvelope> $started */
+        $started = $consumer->consume('test_queue');
+        iterator_to_array($started);
+
+        $message = $this->createMock(AMQPMessage::class);
+        $message->expects($noAck ? self::never() : self::once())
+            ->method('ack');
+        $message->expects($noAck ? self::never() : self::once())
+            ->method('nack');
+
+        $consumer->callback($message);
+
+        /** @var Traversable<AmqpEnvelope> $amqpEnvelopes */
+        $amqpEnvelopes = $consumer->consume('test_queue');
+        $envelopes     = iterator_to_array($amqpEnvelopes);
+
+        self::assertCount(1, $envelopes);
+
+        $envelopes[0]->ack();
+        $envelopes[0]->nack();
     }
 
     protected function setUp(): void

--- a/tests/Unit/Transport/AmqpEnvelopeTest.php
+++ b/tests/Unit/Transport/AmqpEnvelopeTest.php
@@ -60,6 +60,24 @@ class AmqpEnvelopeTest extends TestCase
         $envelope->nack();
     }
 
+    public function testAckDoesNothingWhenNoAck(): void
+    {
+        $message = $this->createMock(AMQPMessage::class);
+        $message->expects(self::never())
+            ->method('ack');
+
+        (new AmqpEnvelope($message, noAck: true))->ack();
+    }
+
+    public function testNackDoesNothingWhenNoAck(): void
+    {
+        $message = $this->createMock(AMQPMessage::class);
+        $message->expects(self::never())
+            ->method('nack');
+
+        (new AmqpEnvelope($message, noAck: true))->nack();
+    }
+
     public function testGetBody(): void
     {
         [$message, $envelope] = $this->createMockEnvelope();

--- a/tests/Unit/Transport/Config/ConnectionConfigTest.php
+++ b/tests/Unit/Transport/Config/ConnectionConfigTest.php
@@ -80,6 +80,7 @@ class ConnectionConfigTest extends TestCase
             'prefetch_count' => 15,
             'fetch_size' => 10,
             'wait_timeout' => 2.0,
+            'no_ack' => true,
             'confirm_enabled' => true,
             'confirm_timeout' => 10.0,
             'retries_enabled' => false,
@@ -130,6 +131,7 @@ class ConnectionConfigTest extends TestCase
         self::assertSame(15, $connectionConfig->prefetchCount);
         self::assertSame(10, $connectionConfig->fetchSize);
         self::assertSame(2.0, $connectionConfig->waitTimeout);
+        self::assertTrue($connectionConfig->noAck);
         self::assertTrue($connectionConfig->confirmEnabled);
         self::assertSame(10.0, $connectionConfig->confirmTimeout);
         self::assertFalse($connectionConfig->retriesEnabled);
@@ -157,11 +159,13 @@ class ConnectionConfigTest extends TestCase
                 name: 'queue1',
                 prefetchCount: 20,
                 waitTimeout: 3.0,
+                noAck: true,
             ),
             'queue2' => new QueueConfig(
                 name: 'queue2',
                 prefetchCount: 30,
                 waitTimeout: 4.0,
+                noAck: true,
             ),
         ], $connectionConfig->queues);
 
@@ -270,6 +274,7 @@ class ConnectionConfigTest extends TestCase
         $connectionConfig = ConnectionConfig::fromArray([
             'prefetch_count' => 10,
             'wait_timeout' => 2,
+            'no_ack' => true,
             'queues' => [
                 'queue1' => [],
             ],
@@ -277,6 +282,7 @@ class ConnectionConfigTest extends TestCase
 
         self::assertSame(10, $connectionConfig->getQueueConfig('queue1')->prefetchCount);
         self::assertSame(2.0, $connectionConfig->getQueueConfig('queue1')->waitTimeout);
+        self::assertTrue($connectionConfig->getQueueConfig('queue1')->noAck);
     }
 
     public function testQueueConfigOverridesConnectionConfig(): void
@@ -284,16 +290,19 @@ class ConnectionConfigTest extends TestCase
         $connectionConfig = ConnectionConfig::fromArray([
             'prefetch_count' => 10,
             'wait_timeout' => 2,
+            'no_ack' => true,
             'queues' => [
                 'queue1' => [
                     'prefetch_count' => 20,
                     'wait_timeout' => 4,
+                    'no_ack' => false,
                 ],
             ],
         ]);
 
         self::assertSame(20, $connectionConfig->getQueueConfig('queue1')->prefetchCount);
         self::assertSame(4.0, $connectionConfig->getQueueConfig('queue1')->waitTimeout);
+        self::assertFalse($connectionConfig->getQueueConfig('queue1')->noAck);
     }
 
     #[TestWith([0])]
@@ -424,6 +433,7 @@ class ConnectionConfigTest extends TestCase
         self::assertSame(1, $connectionConfig->prefetchCount);
         self::assertNull($connectionConfig->fetchSize);
         self::assertSame(1, $connectionConfig->waitTimeout);
+        self::assertFalse($connectionConfig->noAck);
         self::assertTrue($connectionConfig->confirmEnabled);
         self::assertSame(3, $connectionConfig->confirmTimeout);
         self::assertFalse($connectionConfig->transactionsEnabled);

--- a/tests/Unit/Transport/Config/QueueConfigTest.php
+++ b/tests/Unit/Transport/Config/QueueConfigTest.php
@@ -32,6 +32,11 @@ class QueueConfigTest extends TestCase
         self::assertTrue((new QueueConfig(name: 'queue_name', autoDelete: true))->autoDelete);
     }
 
+    public function testNoAckCanBeEnabled(): void
+    {
+        self::assertTrue((new QueueConfig(name: 'queue_name', noAck: true))->noAck);
+    }
+
     public function testFromArrayWithEmptyArray(): void
     {
         self::expectException(InvalidArgumentException::class);
@@ -83,6 +88,7 @@ class QueueConfigTest extends TestCase
             'name' => 'queue_name',
             'prefetch_count' => 10,
             'wait_timeout' => 2.0,
+            'no_ack' => true,
             'passive' => true,
             'durable' => false,
             'exclusive' => true,
@@ -94,6 +100,7 @@ class QueueConfigTest extends TestCase
         self::assertSame('queue_name', $queueConfig->name);
         self::assertSame(10, $queueConfig->prefetchCount);
         self::assertSame(2.0, $queueConfig->waitTimeout);
+        self::assertTrue($queueConfig->noAck);
         self::assertTrue($queueConfig->passive);
         self::assertFalse($queueConfig->durable);
         self::assertTrue($queueConfig->exclusive);
@@ -188,6 +195,7 @@ class QueueConfigTest extends TestCase
         self::assertSame('queue_name', $queueConfig->name);
         self::assertSame(ConnectionConfig::DEFAULT_PREFETCH_COUNT, $queueConfig->prefetchCount);
         self::assertSame(ConnectionConfig::DEFAULT_WAIT_TIMEOUT, $queueConfig->waitTimeout);
+        self::assertFalse($queueConfig->noAck);
         self::assertFalse($queueConfig->passive);
         self::assertTrue($queueConfig->durable);
         self::assertFalse($queueConfig->exclusive);

--- a/tests/Unit/Transport/DsnParserTest.php
+++ b/tests/Unit/Transport/DsnParserTest.php
@@ -280,6 +280,29 @@ class DsnParserTest extends TestCase
         self::assertSame(5, $connectionConfig->fetchSize);
     }
 
+    public function testNoAck(): void
+    {
+        $connectionConfig = $this->dsnParser->parseDsn('phpamqplib://127.0.0.1');
+
+        self::assertFalse($connectionConfig->noAck);
+        self::assertFalse($connectionConfig->queues['messages']->noAck);
+
+        $connectionConfig = $this->dsnParser->parseDsn('phpamqplib://127.0.0.1?no_ack=true');
+
+        self::assertTrue($connectionConfig->noAck);
+        self::assertTrue($connectionConfig->queues['messages']->noAck);
+
+        $connectionConfig = $this->dsnParser->parseDsn('phpamqplib://127.0.0.1', ['no_ack' => true]);
+
+        self::assertTrue($connectionConfig->noAck);
+        self::assertTrue($connectionConfig->queues['messages']->noAck);
+
+        $connectionConfig = $this->dsnParser->parseDsn('phpamqplib://127.0.0.1', ['no_ack' => false]);
+
+        self::assertFalse($connectionConfig->noAck);
+        self::assertFalse($connectionConfig->queues['messages']->noAck);
+    }
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -305,6 +328,7 @@ class DsnParserTest extends TestCase
         self::assertSame(true, $connectionConfig->keepalive);
         self::assertSame('connection_name', $connectionConfig->connectionName);
         self::assertFalse($connectionConfig->retriesEnabled);
+        self::assertTrue($connectionConfig->noAck);
 
         self::assertEquals(new SslConfig(
             cafile: 'cacert',
@@ -337,6 +361,7 @@ class DsnParserTest extends TestCase
         self::assertEquals([
             'queue1' => new QueueConfig(
                 name: 'queue1',
+                noAck: true,
                 passive: true,
                 durable: true,
                 exclusive: true,
@@ -351,6 +376,7 @@ class DsnParserTest extends TestCase
             ),
             'queue2' => new QueueConfig(
                 name: 'queue2',
+                noAck: true,
                 passive: true,
                 durable: true,
                 exclusive: true,
@@ -384,6 +410,7 @@ class DsnParserTest extends TestCase
             'heartbeat' => 5,
             'keepalive' => true,
             'retries_enabled' => false,
+            'no_ack' => true,
             'ssl' => ['cafile' => 'cacert'],
             'exchange' => [
                 'name' => 'exchange_name',


### PR DESCRIPTION
## Summary
- Adds a `no_ack` transport option (connection-level, inherited by queues, overridable per queue) so `basic_consume` can auto-acknowledge deliveries.
- When `no_ack` is true, Messenger `ack`/`reject` (and decode-failure nacks) become no-ops, which avoids `PRECONDITION_FAILED - unknown delivery tag` from sending `basic.ack` after the broker already auto-acked.
- Default remains `false` (at-least-once). Enabling it is at-most-once: a crash during handling can lose the message, failed handlers cannot requeue via nack, and AMQP prefetch has no effect.

Fixes #93.

## Test plan
- [x] Unit tests for config parsing/inheritance, DSN `no_ack=true`, `basic_consume(no_ack: …)`, and skipped ack/nack
- [x] Enable `no_ack: true` against a broker, consume and ack a message, confirm no `unknown delivery tag` channel error
- [x] Confirm the default (`no_ack: false`) still acks and requeues on reject


Made with [Cursor](https://cursor.com)