### PR TITLE
Kill escaped Infection mutants on main

### DIFF
--- a/tests/Unit/EventListener/AmqpWorkerListenerTest.php
+++ b/tests/Unit/EventListener/AmqpWorkerListenerTest.php
@@ -14,6 +14,7 @@ use ReflectionClass;
 use ReflectionMethod;
 use stdClass;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputInterface;
@@ -31,6 +32,19 @@ use function microtime;
 
 class AmqpWorkerListenerTest extends TestCase
 {
+    public function testGetSubscribedEventsRegistersWorkerAndConsoleListeners(): void
+    {
+        self::assertSame(
+            [
+                WorkerStartedEvent::class => 'onWorkerStarted',
+                WorkerRunningEvent::class => 'onWorkerRunning',
+                WorkerStoppedEvent::class => 'onWorkerStopped',
+                ConsoleEvents::COMMAND    => 'onConsoleCommand',
+            ],
+            AmqpWorkerListener::getSubscribedEvents(),
+        );
+    }
+
     public function testOnWorkerStartedStartsConsumersForMatchingPhpAmqpLibTransports(): void
     {
         $connection = $this->createMock(Connection::class);

--- a/tests/Unit/Transport/AmqpTransportTest.php
+++ b/tests/Unit/Transport/AmqpTransportTest.php
@@ -11,8 +11,10 @@ use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpSender;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\AmqpTransport;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\Config\ConnectionConfig;
 use Jwage\PhpAmqpLibMessengerBundle\Transport\Connection;
+use ReflectionMethod;
 use stdClass;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 class AmqpTransportTest extends TestCase
@@ -233,5 +235,27 @@ class AmqpTransportTest extends TestCase
         $transport = $this->createTransport(connection: $connection);
 
         $transport->keepalive(new Envelope(new stdClass()));
+    }
+
+    public function testGetSerializerUsesTheInjectedSerializer(): void
+    {
+        $serializer = $this->createStub(SerializerInterface::class);
+        $transport  = $this->createTransport(serializer: $serializer);
+        $method     = new ReflectionMethod(AmqpTransport::class, 'getSerializer');
+
+        self::assertSame($serializer, $method->invoke($transport));
+        self::assertSame($serializer, $method->invoke($transport));
+    }
+
+    public function testGetSerializerDefaultsToAReusedPhpSerializer(): void
+    {
+        $transport = new AmqpTransport($this->createStub(Connection::class));
+        $method    = new ReflectionMethod(AmqpTransport::class, 'getSerializer');
+
+        $first  = $method->invoke($transport);
+        $second = $method->invoke($transport);
+
+        self::assertInstanceOf(PhpSerializer::class, $first);
+        self::assertSame($first, $second);
     }
 }


### PR DESCRIPTION
## Summary
- Infection on `main` has been failing since it was added: unit tests never exercised `AmqpTransport::getSerializer()` lazy init, and `AmqpWorkerListener::getSubscribedEvents()` was not asserted.
- Add tests that the injected serializer is kept, that a default `PhpSerializer` is reused, and that the worker listener subscribes to started/running/stopped plus `console.command`.

## Test plan
- [x] `./vendor/bin/phpunit --testsuite unit --filter 'AmqpTransportTest|AmqpWorkerListenerTest'`
- [x] Filtered Infection on those two source files: 96 killed / 96 generated (100% MSI)
- [x] CI Infection job on this PR (changed-lines) and, after merge, full Infection on `main`